### PR TITLE
Implement password hashing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import {
 import './App.css';
 import LoginScreen from './components/LoginScreen';
 import { load, save } from './utils/storage';
+import { hashPassword } from './utils/hash';
 
 const App = () => {
   const [activeTab, setActiveTab] = useState('workout');
@@ -210,9 +211,10 @@ const App = () => {
   };
 
   // Fonctions d'authentification
-  const handleLogin = (e) => {
+  const handleLogin = async (e) => {
     e.preventDefault();
-    const user = users.find(u => u.username === loginForm.username && u.password === loginForm.password);
+    const hashed = await hashPassword(loginForm.password);
+    const user = users.find(u => u.username === loginForm.username && u.password === hashed);
     if (user) {
       setCurrentUser(user);
       setShowLogin(false);
@@ -222,7 +224,7 @@ const App = () => {
     }
   };
 
-  const handleRegister = (e) => {
+  const handleRegister = async (e) => {
     e.preventDefault();
     if (registerForm.password !== registerForm.confirmPassword) {
       alert('Les mots de passe ne correspondent pas 🔒');
@@ -241,10 +243,11 @@ const App = () => {
       return;
     }
 
+    const hashed = await hashPassword(registerForm.password);
     const newUser = {
       id: Date.now(),
       username: registerForm.username,
-      password: registerForm.password,
+      password: hashed,
       createdAt: new Date().toISOString()
     };
     

--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -1,0 +1,7 @@
+export const hashPassword = async (password) => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+};


### PR DESCRIPTION
## Summary
- hash passwords with `crypto.subtle.digest` before storing users
- compare hashed passwords on login

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6875817fab788331ad7d251b823496ac