### PR TITLE
Add LoginScreen tests

### DIFF
--- a/src/__tests__/LoginScreen.test.jsx
+++ b/src/__tests__/LoginScreen.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginScreen from '../components/LoginScreen';
+
+describe('LoginScreen', () => {
+  const defaultProps = {
+    loginForm: { username: '', password: '' },
+    setLoginForm: jest.fn(),
+    registerForm: { username: '', password: '', confirmPassword: '' },
+    setRegisterForm: jest.fn(),
+    handleLogin: jest.fn((e) => e.preventDefault()),
+    handleRegister: jest.fn((e) => e.preventDefault()),
+    toggleRegistering: jest.fn(),
+    users: [],
+  };
+
+  test('renders login form when not registering', () => {
+    render(<LoginScreen isRegistering={false} {...defaultProps} />);
+    expect(screen.getByText('Se connecter')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Entrez votre nom d'utilisateur")
+    ).toBeInTheDocument();
+  });
+
+  test('renders register form when registering', () => {
+    render(<LoginScreen isRegistering={true} {...defaultProps} />);
+    expect(screen.getByText('Créer un compte')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Confirmez votre mot de passe')
+    ).toBeInTheDocument();
+  });
+
+  test('calls handleLogin on login submission', async () => {
+    render(<LoginScreen isRegistering={false} {...defaultProps} />);
+    await userEvent.type(
+      screen.getByPlaceholderText("Entrez votre nom d'utilisateur"),
+      'john'
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText('Entrez votre mot de passe'),
+      'secret'
+    );
+    fireEvent.click(screen.getByRole('button', { name: /se connecter/i }));
+    expect(defaultProps.handleLogin).toHaveBeenCalled();
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- create React Testing Library tests for `LoginScreen`
- enable jest-dom matchers in `setupTests.js`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687581775ff483318ef4c7e41206b6ca