### PR TITLE
Add username persistence

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,6 +85,10 @@ const App = () => {
     if (user) {
       setCurrentUser(user);
     }
+    const lastUsername = load('iciCaPousse_lastUsername', '');
+    if (lastUsername) {
+      setLoginForm((lf) => ({ ...lf, username: lastUsername }));
+    }
   }, []);
 
   useEffect(() => {
@@ -219,6 +223,7 @@ const App = () => {
       setCurrentUser(user);
       setShowLogin(false);
       setLoginForm({ username: '', password: '' });
+      save('iciCaPousse_lastUsername', user.username);
     } else {
       alert('Nom d\'utilisateur ou mot de passe incorrect 😕');
     }
@@ -256,6 +261,7 @@ const App = () => {
     setShowLogin(false);
     setRegisterForm({ username: '', password: '', confirmPassword: '' });
     setIsRegistering(false);
+    save('iciCaPousse_lastUsername', newUser.username);
   };
 
   const handleLogout = () => {
@@ -264,6 +270,8 @@ const App = () => {
     setExercises([]);
     setSelectedMuscleGroup(null);
     localStorage.removeItem('iciCaPousse_currentUser');
+    const lastUsername = load('iciCaPousse_lastUsername', '');
+    setLoginForm({ username: lastUsername, password: '' });
     setActiveTab('workout');
   };
 

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -124,9 +124,19 @@ const LoginScreen = ({
       {users.length > 0 && (
         <div className="mt-4 p-3 bg-gray-100 rounded-lg">
           <p className="text-xs text-gray-600 mb-2">Comptes enregistrés ({users.length}) :</p>
-          {users.map((user) => (
-            <div key={user.id} className="text-xs text-gray-500">• {user.username}</div>
-          ))}
+          <ul className="space-y-1">
+            {users.map((user) => (
+              <li key={user.id}>
+                <button
+                  type="button"
+                  onClick={() => setLoginForm({ ...loginForm, username: user.username })}
+                  className="text-xs text-gray-500 hover:text-gray-700"
+                >
+                  • {user.username}
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- remember last used username in login page
- show clickable saved usernames to fill login form

## Testing
- `CI=true npm test -- --watchAll=false --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6875888e640c83318708a0999a02ff31