### PR TITLE
Add tests for workout storage flows

### DIFF
--- a/src/__tests__/CreateWorkout.test.js
+++ b/src/__tests__/CreateWorkout.test.js
@@ -1,0 +1,30 @@
+import { save, load } from '../utils/storage';
+
+describe('workout creation flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(Storage.prototype, 'setItem');
+    jest.spyOn(Storage.prototype, 'getItem');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('saves new workout for logged-in user and retrieves it', () => {
+    const key = 'iciCaPousse_workouts_1';
+    const workout = { id: 1, date: '2024-01-01', exercises: [] };
+
+    save(key, [workout]);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      key,
+      JSON.stringify([workout])
+    );
+
+    const loaded = load(key, []);
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(key);
+    expect(loaded).toEqual([workout]);
+  });
+});

--- a/src/__tests__/DeleteWorkout.test.js
+++ b/src/__tests__/DeleteWorkout.test.js
@@ -1,0 +1,35 @@
+import { save, load } from '../utils/storage';
+
+describe('workout deletion flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(Storage.prototype, 'setItem');
+    jest.spyOn(Storage.prototype, 'getItem');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('removes a workout from storage', () => {
+    const key = 'iciCaPousse_workouts_1';
+    const workouts = [
+      { id: 1, date: '2024-01-01', exercises: [] },
+      { id: 2, date: '2024-01-02', exercises: [] }
+    ];
+    localStorage.setItem(key, JSON.stringify(workouts));
+
+    const remaining = workouts.filter(w => w.id !== 1);
+    save(key, remaining);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      key,
+      JSON.stringify(remaining)
+    );
+
+    const loaded = load(key, []);
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(key);
+    expect(loaded).toEqual(remaining);
+  });
+});

--- a/src/__tests__/EditWorkout.test.js
+++ b/src/__tests__/EditWorkout.test.js
@@ -1,0 +1,32 @@
+import { save, load } from '../utils/storage';
+
+describe('workout editing flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.spyOn(Storage.prototype, 'setItem');
+    jest.spyOn(Storage.prototype, 'getItem');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('edits an existing workout and stores the update', () => {
+    const key = 'iciCaPousse_workouts_1';
+    const workout = { id: 1, date: '2024-01-01', exercises: [], duration: 30 };
+    localStorage.setItem(key, JSON.stringify([workout]));
+
+    const updated = { ...workout, duration: 45 };
+    save(key, [updated]);
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      key,
+      JSON.stringify([updated])
+    );
+
+    const loaded = load(key, []);
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(key);
+    expect(loaded).toEqual([updated]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for creating, editing and deleting workouts
- mock localStorage interactions in storage utilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68758ab4fd3c833199ee7fef4764a478