### PR TITLE
Refactor App to use separate exercise database

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import {
 import './App.css';
 import LoginScreen from './components/LoginScreen';
 import { load, save } from './utils/storage';
+import { exerciseDatabase } from './utils/exerciseDatabase';
 
 
 const App = () => {
@@ -44,41 +45,6 @@ const App = () => {
   const [selectedMuscleGroup, setSelectedMuscleGroup] = useState(null);
 
   // Base de données d'exercices par groupe musculaire
-  const exerciseDatabase = {
-    pectoraux: [
-      'Développé couché', 'Développé incliné', 'Développé décliné', 'Pompes', 'Écarté couché',
-      'Écarté incliné', 'Développé haltères', 'Dips', 'Pull-over', 'Pec deck'
-    ],
-    dos: [
-      'Tractions', 'Rowing barre', 'Rowing haltères', 'Tirage horizontal', 'Tirage vertical',
-      'Soulevé de terre', 'Rowing T-bar', 'Shrugs', 'Hyperextensions', 'Tirage poulie haute'
-    ],
-    épaules: [
-      'Développé militaire', 'Élévations latérales', 'Élévations frontales', 'Oiseau',
-      'Développé Arnold', 'Upright row', 'Face pull', 'Handstand push-up'
-    ],
-    biceps: [
-      'Curl barre', 'Curl haltères', 'Curl marteau', 'Curl concentré', 'Curl pupitre',
-      'Curl 21', 'Traction supination', 'Curl câble'
-    ],
-    triceps: [
-      'Dips', 'Extension couché', 'Extension verticale', 'Pompes diamant', 'Kick back',
-      'Extension poulie haute', 'Développé serré'
-    ],
-    jambes: [
-      'Squat', 'Leg press', 'Fentes', 'Leg curl', 'Leg extension', 'Soulevé de terre roumain',
-      'Mollets debout', 'Mollets assis', 'Hack squat', 'Goblet squat'
-    ],
-    abdos: [
-      'Crunch', 'Planche', 'Relevé de jambes', 'Russian twist', 'Mountain climbers',
-      'Bicycle crunch', 'Dead bug', 'Hanging knee raise'
-    ],
-    cardio: [
-      'Course à pied', 'Vélo', 'Elliptique', 'Rameur', 'Tapis de course', 'Vélo spinning',
-      'Stepper', 'Corde à sauter', 'Burpees', 'Jumping jacks', 'High knees', 'Montées de genoux',
-      'Sprint', 'Marche rapide', 'Natation', 'Aquabike', 'HIIT', 'Tabata'
-    ]
-  };
 
   useEffect(() => {
     const lastUsername = load('iciCaPousse_lastUsername', '');

--- a/src/utils/exerciseDatabase.js
+++ b/src/utils/exerciseDatabase.js
@@ -1,0 +1,35 @@
+export const exerciseDatabase = {
+  pectoraux: [
+    'Développé couché', 'Développé incliné', 'Développé décliné', 'Pompes', 'Écarté couché',
+    'Écarté incliné', 'Développé haltères', 'Dips', 'Pull-over', 'Pec deck'
+  ],
+  dos: [
+    'Tractions', 'Rowing barre', 'Rowing haltères', 'Tirage horizontal', 'Tirage vertical',
+    'Soulevé de terre', 'Rowing T-bar', 'Shrugs', 'Hyperextensions', 'Tirage poulie haute'
+  ],
+  épaules: [
+    'Développé militaire', 'Élévations latérales', 'Élévations frontales', 'Oiseau',
+    'Développé Arnold', 'Upright row', 'Face pull', 'Handstand push-up'
+  ],
+  biceps: [
+    'Curl barre', 'Curl haltères', 'Curl marteau', 'Curl concentré', 'Curl pupitre',
+    'Curl 21', 'Traction supination', 'Curl câble'
+  ],
+  triceps: [
+    'Dips', 'Extension couché', 'Extension verticale', 'Pompes diamant', 'Kick back',
+    'Extension poulie haute', 'Développé serré'
+  ],
+  jambes: [
+    'Squat', 'Leg press', 'Fentes', 'Leg curl', 'Leg extension', 'Soulevé de terre roumain',
+    'Mollets debout', 'Mollets assis', 'Hack squat', 'Goblet squat'
+  ],
+  abdos: [
+    'Crunch', 'Planche', 'Relevé de jambes', 'Russian twist', 'Mountain climbers',
+    'Bicycle crunch', 'Dead bug', 'Hanging knee raise'
+  ],
+  cardio: [
+    'Course à pied', 'Vélo', 'Elliptique', 'Rameur', 'Tapis de course', 'Vélo spinning',
+    'Stepper', 'Corde à sauter', 'Burpees', 'Jumping jacks', 'High knees', 'Montées de genoux',
+    'Sprint', 'Marche rapide', 'Natation', 'Aquabike', 'HIIT', 'Tabata'
+  ]
+};


### PR DESCRIPTION
## Summary
- extract `exerciseDatabase` into `src/utils/exerciseDatabase.js`
- import the database in `App.js`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68758f2e43f48331888f46345d7427ad