### PR TITLE
Add API base URL config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ cd ici-ca-pousse
 npm install
 ```
 
-### 3. Test en local
+### 3. Configuration
+
+Crée un fichier `.env` à la racine et indique l'URL de ton API :
+
+```env
+REACT_APP_API_BASE_URL="http://localhost:3001"
+```
+
+### 4. Test en local
 
 ```bash
 # Lance l'application en développement
@@ -120,6 +128,7 @@ Crée `vercel.json` à la racine :
 Pour des fonctionnalités avancées, crée `.env` :
 
 ```env
+REACT_APP_API_BASE_URL="http://localhost:3001"
 REACT_APP_NAME="Ici Ca Pousse"
 REACT_APP_VERSION="1.0.0"
 GENERATE_SOURCEMAP=false

--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,7 @@ const App = () => {
 
     const storedToken = load('iciCaPousse_token', null);
     if (storedToken) {
-      fetch('http://localhost:3001/api/validate', {
+      fetch(`${process.env.REACT_APP_API_BASE_URL}/api/validate`, {
         headers: { Authorization: `Bearer ${storedToken}` },
       })
         .then((res) => (res.ok ? res.json() : null))
@@ -69,7 +69,7 @@ const App = () => {
         .catch(() => {});
     }
 
-    fetch('http://localhost:3001/api/users')
+    fetch(`${process.env.REACT_APP_API_BASE_URL}/api/users`)
       .then((res) => (res.ok ? res.json() : []))
       .then(setUsers)
       .catch(() => setUsers([]));
@@ -203,7 +203,7 @@ const App = () => {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:3001/api/login', {
+      const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/api/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(loginForm),
@@ -238,7 +238,7 @@ const App = () => {
       return;
     }
     try {
-      const res = await fetch('http://localhost:3001/api/register', {
+      const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/api/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username: registerForm.username, password: registerForm.password }),
@@ -251,7 +251,7 @@ const App = () => {
         setRegisterForm({ username: '', password: '', confirmPassword: '' });
         setIsRegistering(false);
         save('iciCaPousse_lastUsername', data.user.username);
-        fetch('http://localhost:3001/api/users')
+        fetch(`${process.env.REACT_APP_API_BASE_URL}/api/users`)
           .then((r) => (r.ok ? r.json() : []))
           .then(setUsers)
           .catch(() => {});


### PR DESCRIPTION
## Summary
- add `.env` for config
- switch API calls to `process.env.REACT_APP_API_BASE_URL`
- document how to set API URL in README

## Testing
- `npm test`
- `npm start` *(fails: Something is already running on port 3000)*

------
https://chatgpt.com/codex/tasks/task_e_687591b4b2108331ae894139e2ac9ee1