### PR TITLE
Restore local auth URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm install
 ```bash
 # Lance l'application en développement
 npm start
+# Démarre le serveur d'authentification
+node server.js
 ```
 
 L'app sera accessible sur http://localhost:3000

--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ const App = () => {
 
     const storedToken = load('iciCaPousse_token', null);
     if (storedToken) {
-      fetch('/api/validate', {
+      fetch('http://localhost:3001/api/validate', {
         headers: { Authorization: `Bearer ${storedToken}` },
       })
         .then((res) => (res.ok ? res.json() : null))
@@ -72,7 +72,7 @@ const App = () => {
         .catch(() => {});
     }
 
-    fetch('/api/users')
+    fetch('http://localhost:3001/api/users')
       .then((res) => (res.ok ? res.json() : []))
       .then(setUsers)
       .catch(() => setUsers([]));
@@ -206,7 +206,7 @@ const App = () => {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch('/api/login', {
+      const res = await fetch('http://localhost:3001/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(loginForm),
@@ -241,7 +241,7 @@ const App = () => {
       return;
     }
     try {
-      const res = await fetch('/api/register', {
+      const res = await fetch('http://localhost:3001/api/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username: registerForm.username, password: registerForm.password }),
@@ -254,7 +254,7 @@ const App = () => {
         setRegisterForm({ username: '', password: '', confirmPassword: '' });
         setIsRegistering(false);
         save('iciCaPousse_lastUsername', data.user.username);
-        fetch('/api/users')
+        fetch('http://localhost:3001/api/users')
           .then((r) => (r.ok ? r.json() : []))
           .then(setUsers)
           .catch(() => {});


### PR DESCRIPTION
## Summary
- revert API calls to use explicit `http://localhost:3001` base
- note starting `server.js` in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687596b8b3fc83318b3a9b90cdd8fa75