### PR TITLE
Refactor localStorage keys

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,7 @@ import {
 
 // Utils
 import { migrateLocalWorkoutsToCloud } from './utils/storage';
+import { STORAGE_KEYS } from './constants';
 
 function App() {
   const { user, loading: userLoading, refreshUserProfile } = useUserProfile();
@@ -137,7 +138,7 @@ function App() {
   useEffect(() => {
     if (user) {
       // Vérifier s'il y a des données locales à migrer
-      const localWorkouts = JSON.parse(localStorage.getItem('iciCaPousse_workouts') || '[]');
+      const localWorkouts = JSON.parse(localStorage.getItem(STORAGE_KEYS.WORKOUTS) || '[]');
       if (localWorkouts.length > 0) {
         setShowMigratePrompt(true);
       }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -7,6 +7,7 @@ import ProfileSettings from '../Profile/ProfileSettings';
 import ProfilePicture from '../Profile/ProfilePicture';
 import { useExperience } from '../../hooks/useExperience.js';
 import StreakCounter from '../StreakCounter';
+import { STORAGE_KEYS } from '../../constants';
 
 const Header = memo(({ workoutCount, className = '', user, workouts = [], challenges = [], addBadgeUnlockXP, onUserUpdate, refreshUserProfile }) => {
   const [showProfile, setShowProfile] = React.useState(false);
@@ -18,7 +19,7 @@ const Header = memo(({ workoutCount, className = '', user, workouts = [], challe
 
   // Dark mode: détecte le mode système à l'init
   useEffect(() => {
-    const saved = localStorage.getItem('theme');
+    const saved = localStorage.getItem(STORAGE_KEYS.THEME);
     if (saved) {
       setTheme(saved);
       document.body.classList.toggle('dark', saved === 'dark');
@@ -32,7 +33,7 @@ const Header = memo(({ workoutCount, className = '', user, workouts = [], challe
   // Applique la classe dark/light sur le body à chaque changement
   useEffect(() => {
     document.body.classList.toggle('dark', theme === 'dark');
-    localStorage.setItem('theme', theme);
+    localStorage.setItem(STORAGE_KEYS.THEME, theme);
   }, [theme]);
 
   const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');

--- a/src/components/Workout/WorkoutList/WorkoutList.jsx
+++ b/src/components/Workout/WorkoutList/WorkoutList.jsx
@@ -1,5 +1,6 @@
 import React, { memo, useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { STORAGE_KEYS } from '../../../constants';
 import { db } from '../../../utils/firebase';
 import { doc, setDoc, onSnapshot } from 'firebase/firestore';
 import {
@@ -79,7 +80,7 @@ function WorkoutList({
     } else {
       // Fallback localStorage
       try {
-        setFavoriteExercises(JSON.parse(localStorage.getItem('favoriteExercises') || '[]'));
+        setFavoriteExercises(JSON.parse(localStorage.getItem(STORAGE_KEYS.FAVORITE_EXERCISES) || '[]'));
       } catch {
         setFavoriteExercises([]);
       }
@@ -92,18 +93,18 @@ function WorkoutList({
       const favRef = doc(db, 'favorites', user.uid);
       setDoc(favRef, { exercises: favoriteExercises }, { merge: true });
     } else {
-      localStorage.setItem('favoriteExercises', JSON.stringify(favoriteExercises));
+      localStorage.setItem(STORAGE_KEYS.FAVORITE_EXERCISES, JSON.stringify(favoriteExercises));
     }
   }, [favoriteExercises, user]);
 
   // Migration favoris locaux -> cloud
   useEffect(() => {
     if (user) {
-      const localFavs = JSON.parse(localStorage.getItem('favoriteExercises') || '[]');
+      const localFavs = JSON.parse(localStorage.getItem(STORAGE_KEYS.FAVORITE_EXERCISES) || '[]');
       if (localFavs.length > 0) {
         const favRef = doc(db, 'favorites', user.uid);
         setDoc(favRef, { exercises: localFavs }, { merge: true });
-        localStorage.setItem('favoriteExercises', '[]');
+        localStorage.setItem(STORAGE_KEYS.FAVORITE_EXERCISES, '[]');
       }
     }
   }, [user]);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
 // Constants exports
 export * from './badges';
-export * from './leaderboard'; 
+export * from './leaderboard';
+export * from './storageKeys';

--- a/src/constants/storageKeys.js
+++ b/src/constants/storageKeys.js
@@ -1,0 +1,5 @@
+export const STORAGE_KEYS = {
+  WORKOUTS: 'iciCaPousse_workouts',
+  FAVORITE_EXERCISES: 'favoriteExercises',
+  THEME: 'theme'
+};

--- a/src/hooks/useWorkouts.js
+++ b/src/hooks/useWorkouts.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { load, save } from '../utils/storage';
+import { STORAGE_KEYS } from '../constants';
 import { db } from '../utils/firebase';
 import { collection, query, where, onSnapshot, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
 import { cleanWorkoutForFirestore } from '../utils/workoutUtils';
@@ -17,7 +18,7 @@ export const useWorkouts = (user) => {
       return unsubscribe;
     } else {
       // Fallback localStorage
-      const savedWorkouts = load('iciCaPousse_workouts', []);
+      const savedWorkouts = load(STORAGE_KEYS.WORKOUTS, []);
       setWorkouts(savedWorkouts);
     }
   }, [user]);
@@ -25,7 +26,7 @@ export const useWorkouts = (user) => {
   // Sauvegarde locale si pas connecté
   useEffect(() => {
     if (!user) {
-      save('iciCaPousse_workouts', workouts);
+      save(STORAGE_KEYS.WORKOUTS, workouts);
     }
   }, [workouts, user]);
 

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,3 +1,4 @@
+import { STORAGE_KEYS } from "../constants";
 export const load = (key, defaultValue) => {
   try {
     const raw = localStorage.getItem(key);
@@ -17,22 +18,23 @@ export const save = (key, value) => {
 };
 
 export const migrateLocalWorkoutsToCloud = async (user, addWorkoutCloud) => {
-  const localWorkouts = load('iciCaPousse_workouts', []);
+  const localWorkouts = load(STORAGE_KEYS.WORKOUTS, []);
   if (user && localWorkouts.length > 0) {
     for (const workout of localWorkouts) {
       const { id, ...workoutWithoutId } = workout;
       await addWorkoutCloud({ ...workoutWithoutId, userId: user.uid });
     }
     // Optionnel : vider le localStorage après migration
-    save('iciCaPousse_workouts', []);
+    save(STORAGE_KEYS.WORKOUTS, []);
   }
 };
 
 export const migrateLocalFavoritesToCloud = async (user, setFavoriteCloud) => {
-  const localFavorites = load('favoriteExercises', []);
+  const localFavorites = load(STORAGE_KEYS.FAVORITE_EXERCISES, []);
   if (user && localFavorites.length > 0) {
     await setFavoriteCloud(localFavorites);
     // Optionnel : vider le localStorage après migration
-    save('favoriteExercises', []);
+    save(STORAGE_KEYS.FAVORITE_EXERCISES, []);
   }
 };
+


### PR DESCRIPTION
## Summary
- centralize storage keys in `STORAGE_KEYS`
- use the constants across the app for theme, workouts and favorites

## Testing
- `npm test --silent -- --watchAll=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68808357e3c083319f32ad081a37c06a