### PR TITLE
Add utility tests

### DIFF
--- a/src/tests/utils/leaderboardUtils.test.js
+++ b/src/tests/utils/leaderboardUtils.test.js
@@ -1,0 +1,72 @@
+import {
+  getStartDate,
+  filterWorkoutsByPeriod,
+  calculateUserStats,
+  getLeaderboardRanking,
+  formatMetricValue,
+  getPeriodLabel,
+  getMetricLabel,
+  getAllowedExercises
+} from '../../utils/leaderboardUtils';
+import { PERIODS, METRICS, ALLOWED_EXERCISES } from '../../constants/leaderboard';
+
+describe('leaderboardUtils', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-08T12:00:00Z'));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('computes start dates correctly', () => {
+    expect(getStartDate(PERIODS.WEEK)).toEqual(new Date('2024-01-01T12:00:00.000Z'));
+    expect(getStartDate(PERIODS.MONTH)).toEqual(new Date('2023-12-08T12:00:00.000Z'));
+    expect(getStartDate(PERIODS.YEAR)).toEqual(new Date('2023-01-08T12:00:00.000Z'));
+    expect(getStartDate(PERIODS.ALL_TIME)).toEqual(new Date(0));
+  });
+
+  it('filters workouts by period', () => {
+    const workouts = [
+      { date: '2024-01-07' },
+      { date: '2023-12-20' },
+      { date: '2023-10-01' }
+    ];
+    expect(filterWorkoutsByPeriod(workouts, PERIODS.WEEK)).toHaveLength(1);
+    expect(filterWorkoutsByPeriod(workouts, PERIODS.MONTH)).toHaveLength(2);
+    expect(filterWorkoutsByPeriod(workouts, PERIODS.YEAR)).toHaveLength(3);
+  });
+
+  it('calculates stats and ranking', () => {
+    const workouts = [
+      {
+        date: '2024-01-07',
+        exercises: [
+          { name: 'Squat', sets: [{ reps: 5, weight: 100 }] },
+          { name: 'Soulevé de terre', sets: [{ reps: 5, weight: 120 }] }
+        ]
+      },
+      {
+        date: '2023-12-31',
+        exercises: [
+          { name: 'Squat', sets: [{ reps: 5, weight: 110 }] }
+        ]
+      }
+    ];
+    const stats = calculateUserStats(workouts, PERIODS.ALL_TIME);
+    expect(stats.workouts).toBe(2);
+    expect(stats.maxWeight).toBe(120);
+    const ranking = getLeaderboardRanking([
+      { uid: 'a', displayName: 'A', stats },
+      { uid: 'b', displayName: 'B', stats: { workouts: 1, maxWeight: 50 } }
+    ], METRICS.WORKOUTS);
+    expect(ranking[0].uid).toBe('a');
+    expect(ranking[0].rank).toBe(1);
+  });
+
+  it('formats labels and exposes constants', () => {
+    expect(formatMetricValue(5, METRICS.WORKOUTS)).toBe('5 séances');
+    expect(getPeriodLabel(PERIODS.MONTH)).toBe('Ce mois');
+    expect(getMetricLabel(METRICS.MAX_WEIGHT)).toBe('Poids max');
+    expect(getAllowedExercises()).toEqual(ALLOWED_EXERCISES);
+  });
+});

--- a/src/tests/utils/workoutUtils.test.js
+++ b/src/tests/utils/workoutUtils.test.js
@@ -1,0 +1,74 @@
+import {
+  parseLocalDate,
+  createWorkout,
+  calculateWorkoutStats,
+  formatDate,
+  getCurrentDate,
+  getBadges,
+  analyzeWorkoutHabits,
+  getPreferredWorkoutTime,
+  getAverageDurationByTime,
+  getWorkoutsForDateRange,
+  cleanWorkoutForFirestore
+} from '../../utils/workoutUtils';
+
+describe('workoutUtils', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-08T12:00:00Z'));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('parses local dates', () => {
+    const d = parseLocalDate('2024-01-05');
+    expect(d.getFullYear()).toBe(2024);
+    expect(d.getMonth()).toBe(0);
+    expect(d.getDate()).toBe(5);
+    expect(parseLocalDate(null)).toBeNull();
+  });
+
+  it('creates workouts and calculates stats', () => {
+    const workout = createWorkout([{ name: 'Squat', sets: [{ reps: 5, weight: 100 }] }], '2024-01-05', 45, 'id', '10:00', '11:00');
+    expect(workout.totalSets).toBe(1);
+    expect(workout.totalReps).toBe(5);
+    expect(workout.totalWeight).toBe(500);
+    const stats = calculateWorkoutStats([workout]);
+    expect(stats.totalWorkouts).toBe(1);
+  });
+
+  it('formats date and gets current date', () => {
+    const spy = jest.spyOn(Date.prototype, 'toLocaleDateString').mockReturnValue('lun. 08 janv.');
+    expect(formatDate('2024-01-08')).toBe('lun. 08 janv.');
+    expect(getCurrentDate()).toBe('2024-01-08');
+    spy.mockRestore();
+  });
+
+  it('generates badges', () => {
+    const badges = getBadges({ totalWorkouts: 10, totalSets: 120, totalReps: 1500, totalWeight: 12000, avgDuration: 61 });
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it('analyses habits and preferences', () => {
+    const workouts = [
+      { startTime: '06:00', duration: 30 },
+      { startTime: '14:00', duration: 45 },
+      { startTime: '20:00', duration: 20 },
+      { startTime: '23:00', duration: 40 }
+    ];
+    const habits = analyzeWorkoutHabits(workouts);
+    expect(habits.night.count).toBe(1);
+    const pref = getPreferredWorkoutTime(workouts);
+    expect(pref.name).toBe('matin');
+    const avg = getAverageDurationByTime(workouts.map(w => ({ ...w, date: '2024-01-05' })));
+    expect(avg.afternoon).toBe(45);
+  });
+
+  it('filters workouts and cleans for firestore', () => {
+    const ws = [{ date: '2024-01-05' }, { date: '2024-01-10' }];
+    const range = getWorkoutsForDateRange(ws, new Date('2024-01-07'), new Date('2024-01-12'));
+    expect(range).toHaveLength(1);
+    const cleaned = cleanWorkoutForFirestore({ a: 1, b: null, c: { d: 2, e: undefined } });
+    expect(cleaned).toEqual({ a: 1, c: { d: 2 } });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for leaderboard utils
- add unit tests for workout utils

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6880ec057d28833184bb7a32a5a6448e