### PR TITLE
Remove badges from statistics page

### DIFF
--- a/src/components/StatsView/StatsView.jsx
+++ b/src/components/StatsView/StatsView.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { BarChart3, Dumbbell, Target, TrendingUp, Clock, Zap, Calendar, Edit3 } from 'lucide-react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
-import { getBadges, parseLocalDate, analyzeWorkoutHabits, getPreferredWorkoutTime, getAverageDurationByTime } from '../../utils/workoutUtils';
+import { parseLocalDate, analyzeWorkoutHabits, getPreferredWorkoutTime, getAverageDurationByTime } from '../../utils/workoutUtils';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
@@ -69,7 +69,6 @@ const StatsView = ({ stats, workouts, onEditWorkout, className = '' }) => {
   // Trie les séances par date décroissante
   const sortedWorkouts = [...workouts].sort((a, b) => new Date(b.date) - new Date(a.date));
   const weeks = groupWorkoutsByWeek(workouts);
-  const badges = getBadges(stats);
   const workoutHabits = analyzeWorkoutHabits(workouts);
   const preferredTime = getPreferredWorkoutTime(workouts);
   const avgDurationByTime = getAverageDurationByTime(workouts);
@@ -221,16 +220,6 @@ const StatsView = ({ stats, workouts, onEditWorkout, className = '' }) => {
               </div>
             </div>
           </div>
-        </div>
-      )}
-      {badges.length > 0 && (
-        <div className="flex flex-wrap gap-3 mt-6">
-          {badges.map(badge => (
-            <div key={badge.key} className="badge bg-gradient-to-r from-yellow-100 to-yellow-300 border border-yellow-300 shadow text-yellow-800 flex items-center gap-2">
-              <span className="text-xl">{badge.icon}</span>
-              <span>{t(badge.key, { defaultValue: badge.label })}</span>
-            </div>
-          ))}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- remove badges display from StatsView

## Testing
- `npm install`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68813282f28c8331a2076dee7a50709a