### PR TITLE
Fix build errors in calendar and stats views

### DIFF
--- a/src/components/CalendarView/CalendarView.jsx
+++ b/src/components/CalendarView/CalendarView.jsx
@@ -12,9 +12,12 @@ const groupWorkoutsByWeek = (workouts) => {
     if (!date) return;
     const week = `${date.getFullYear()}-W${String(
       Math.ceil(
-        ((date - new Date(date.getFullYear(), 0, 1)) / 86400000 + new Date(date.getFullYear(), 0, 1).getDay() + 1) /
+        ((date - new Date(date.getFullYear(), 0, 1)) / 86400000 +
+          new Date(date.getFullYear(), 0, 1).getDay() +
+          1) /
           7
-      ).padStart(2, '0')}`;
+      )
+    ).padStart(2, '0')}`;
     if (!weeks[week]) weeks[week] = [];
     weeks[week].push(w);
   });

--- a/src/components/StatsView/StatsView.jsx
+++ b/src/components/StatsView/StatsView.jsx
@@ -38,7 +38,6 @@ const StatsView = ({ stats, workouts, className = '' }) => {
   const { t, i18n } = useTranslation();
   // Trie les séances par date décroissante
   const sortedWorkouts = [...workouts].sort((a, b) => new Date(b.date) - new Date(a.date));
-  const weeks = groupWorkoutsByWeek(workouts);
   const workoutHabits = analyzeWorkoutHabits(workouts);
   const preferredTime = getPreferredWorkoutTime(workouts);
   const avgDurationByTime = getAverageDurationByTime(workouts);


### PR DESCRIPTION
## Summary
- correct template string parentheses in CalendarView
- remove unused variable in StatsView

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688137bc3f988331823f54ee0a06d613