### PR TITLE
Fix eslint unused variables in StatsView

### DIFF
--- a/src/components/StatsView/StatsView.jsx
+++ b/src/components/StatsView/StatsView.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { BarChart3, Dumbbell, Target, TrendingUp, Clock, Zap } from 'lucide-react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { parseLocalDate, analyzeWorkoutHabits, getPreferredWorkoutTime, getAverageDurationByTime } from '../../utils/workoutUtils';
@@ -35,13 +35,10 @@ function getMostWorkedMuscleGroup(workouts) {
 
 
 const StatsView = ({ stats, workouts, className = '' }) => {
-  const { t, i18n } = useTranslation();
-  // Trie les séances par date décroissante
-  const sortedWorkouts = [...workouts].sort((a, b) => new Date(b.date) - new Date(a.date));
+  const { t } = useTranslation();
   const workoutHabits = analyzeWorkoutHabits(workouts);
   const preferredTime = getPreferredWorkoutTime(workouts);
   const avgDurationByTime = getAverageDurationByTime(workouts);
-  const dateLocale = i18n.language === 'fr' ? 'fr-FR' : undefined;
 
   return (
     <div className={`p-6 space-y-8 ${className}`}>


### PR DESCRIPTION
## Summary
- remove unused `useState` import
- delete unused variables from `StatsView`

## Testing
- `npm run lint`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881391199e0833192f486f88b39edb6