### PR TITLE
Fix decimal weight handling

### DIFF
--- a/src/tests/utils/workoutUtils.test.js
+++ b/src/tests/utils/workoutUtils.test.js
@@ -37,6 +37,14 @@ describe('workoutUtils', () => {
     expect(stats.totalWorkouts).toBe(1);
   });
 
+  it('handles decimal weights correctly', () => {
+    const workout = createWorkout([
+      { name: 'Bench', sets: [{ reps: 2, weight: 4.5 }] }
+    ], '2024-01-05', 30);
+    expect(workout.exercises[0].sets[0].weight).toBe(4.5);
+    expect(workout.totalWeight).toBeCloseTo(9);
+  });
+
   it('formats date and gets current date', () => {
     const spy = jest.spyOn(Date.prototype, 'toLocaleDateString').mockReturnValue('lun. 08 janv.');
     expect(formatDate('2024-01-08')).toBe('lun. 08 janv.');

--- a/src/utils/workoutUtils.js
+++ b/src/utils/workoutUtils.js
@@ -21,7 +21,7 @@ export const createWorkout = (exercises, date, duration, workoutId = undefined, 
     type: exercise.type || 'custom', // Type par défaut si manquant
     sets: (exercise.sets || [{ reps: 0, weight: 0, duration: 0 }]).map(set => ({
       reps: parseInt(set.reps) || 0,
-      weight: parseInt(set.weight) || 0,
+      weight: parseFloat(set.weight) || 0,
       duration: parseInt(set.duration) || 0
     }))
   }));


### PR DESCRIPTION
## Summary
- allow decimal weights when creating workouts
- test creating workouts with fractional weights

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68813e9561c083319f439409110c43a7