### PR TITLE
Fix decimal weight handling

### DIFF
--- a/src/utils/workoutUtils.js
+++ b/src/utils/workoutUtils.js
@@ -21,7 +21,7 @@ export const createWorkout = (exercises, date, duration, workoutId = undefined, 
     type: exercise.type || 'custom', // Type par défaut si manquant
     sets: (exercise.sets || [{ reps: 0, weight: 0, duration: 0 }]).map(set => ({
       reps: parseInt(set.reps) || 0,
-      weight: parseFloat(set.weight) || 0,
+      weight: parseFloat(String(set.weight).replace(',', '.')) || 0,
       duration: parseInt(set.duration) || 0
     }))
   }));


### PR DESCRIPTION
## Summary
- preserve decimal weights when creating workouts by replacing commas

## Testing
- `CI=true npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6881423ac1408331a84df01fb277b320