### PR TITLE
Fix build lint errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -105,7 +105,7 @@ function App() {
   );
   const { friends } = useFriends(user, addFriendXP);
   const { notifications } = useNotifications(user);
-  const { templates, saveTemplate, getTemplate } = useWorkoutTemplates();
+  const { templates, saveTemplate } = useWorkoutTemplates();
   const { t } = useTranslation();
 
   // Hook personnalisé pour la logique des workouts
@@ -173,7 +173,7 @@ function App() {
         // ignore parsing errors
       }
     }
-  }, []);
+  }, [setExercisesFromWorkout, setSelectedDate, setStartTime, setEndTime]);
 
   // Sauvegarder le brouillon à chaque modification
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove unused variable `getTemplate`
- add stable state setters to `useEffect` dependency array

## Testing
- `npm run lint`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_688145a334508331a60b1da0aebfbb15