### PR TITLE
Persist workout session on refresh

### DIFF
--- a/src/constants/storageKeys.js
+++ b/src/constants/storageKeys.js
@@ -1,5 +1,6 @@
 export const STORAGE_KEYS = {
   WORKOUTS: 'iciCaPousse_workouts',
   FAVORITE_EXERCISES: 'favoriteExercises',
-  THEME: 'theme'
+  THEME: 'theme',
+  CURRENT_WORKOUT: 'currentWorkout',
 };

--- a/src/hooks/useAppState.js
+++ b/src/hooks/useAppState.js
@@ -1,34 +1,51 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { load, save } from '../utils/storage';
+import { STORAGE_KEYS } from '../constants';
 
 export default function useAppState() {
   // État de l'onglet actif
   const [activeTab, setActiveTab] = useState('workout');
-  
+
   // État des toasts
-  const [toast, setToast] = useState({ show: false, message: '', type: 'success' });
-  
+  const [toast, setToast] = useState({
+    show: false,
+    message: '',
+    type: 'success',
+  });
+
   // État de la date sélectionnée
   const [selectedDate, setSelectedDate] = useState(() => {
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    if (saved.selectedDate) return saved.selectedDate;
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
     const day = String(now.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   });
-  
+
   // États des modals et formulaires
   const [showAddExercise, setShowAddExercise] = useState(false);
   const [selectedWorkout, setSelectedWorkout] = useState(null);
   const [showWorkoutDetail, setShowWorkoutDetail] = useState(false);
-  const [startTime, setStartTime] = useState('');
-  const [endTime, setEndTime] = useState('');
+  const [startTime, setStartTime] = useState(() => {
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    return saved.startTime || '';
+  });
+  const [endTime, setEndTime] = useState(() => {
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    return saved.endTime || '';
+  });
   const [selectedMuscleGroup, setSelectedMuscleGroup] = useState(null);
   const [showMigratePrompt, setShowMigratePrompt] = useState(false);
 
   // Fonction utilitaire pour les toasts
   const showToastMsg = useCallback((message, type = 'success') => {
     setToast({ show: true, message, type });
-    setTimeout(() => setToast({ show: false, message: '', type: 'success' }), 2500);
+    setTimeout(
+      () => setToast({ show: false, message: '', type: 'success' }),
+      2500
+    );
   }, []);
 
   // Fonction pour nettoyer le formulaire de workout
@@ -38,7 +55,25 @@ export default function useAppState() {
     setSelectedWorkout(null);
     setShowAddExercise(false);
     setSelectedMuscleGroup(null);
+    localStorage.removeItem(STORAGE_KEYS.CURRENT_WORKOUT);
   }, []);
+
+  useEffect(() => {
+    if (!startTime && !endTime) {
+      const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+      if (!saved.exercises || saved.exercises.length === 0) {
+        localStorage.removeItem(STORAGE_KEYS.CURRENT_WORKOUT);
+        return;
+      }
+    }
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    save(STORAGE_KEYS.CURRENT_WORKOUT, {
+      ...saved,
+      startTime,
+      endTime,
+      selectedDate,
+    });
+  }, [startTime, endTime, selectedDate]);
 
   return {
     // États
@@ -52,7 +87,7 @@ export default function useAppState() {
     endTime,
     selectedMuscleGroup,
     showMigratePrompt,
-    
+
     // Setters
     setActiveTab,
     setToast,
@@ -64,9 +99,9 @@ export default function useAppState() {
     setEndTime,
     setSelectedMuscleGroup,
     setShowMigratePrompt,
-    
+
     // Fonctions utilitaires
     showToastMsg,
-    clearWorkoutForm
+    clearWorkoutForm,
   };
-} 
+}

--- a/src/hooks/useExercises.js
+++ b/src/hooks/useExercises.js
@@ -1,78 +1,107 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { exerciseDatabase } from '../utils/exerciseDatabase';
+import { load, save } from '../utils/storage';
+import { STORAGE_KEYS } from '../constants';
 
 export const useExercises = () => {
-  const [exercises, setExercises] = useState([]);
+  const [exercises, setExercises] = useState(() => {
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    return saved.exercises || [];
+  });
   const [selectedMuscleGroup, setSelectedMuscleGroup] = useState(null);
 
   const addExercise = (exerciseName, muscleGroup = null) => {
     if (!exerciseName || exerciseName.trim() === '') return;
-    
+
     const newExercise = {
       id: Date.now(),
       name: exerciseName.trim(),
       sets: [{ reps: 0, weight: 0, duration: 0 }],
-      type: muscleGroup || Object.keys(exerciseDatabase).find(key => 
-        exerciseDatabase[key].includes(exerciseName)
-      ) || 'custom' // Utilise la catégorie sélectionnée ou trouve automatiquement
+      type:
+        muscleGroup ||
+        Object.keys(exerciseDatabase).find((key) =>
+          exerciseDatabase[key].includes(exerciseName)
+        ) ||
+        'custom', // Utilise la catégorie sélectionnée ou trouve automatiquement
     };
-    setExercises(prev => [...prev, newExercise]);
+    setExercises((prev) => [...prev, newExercise]);
     setSelectedMuscleGroup(null);
   };
 
   const updateExercise = (exerciseId, updatedExercise) => {
-    setExercises(prev => prev.map(ex => 
-      ex.id === exerciseId ? updatedExercise : ex
-    ));
+    setExercises((prev) =>
+      prev.map((ex) => (ex.id === exerciseId ? updatedExercise : ex))
+    );
   };
 
   const removeExercise = (exerciseId) => {
-    setExercises(prev => prev.filter(ex => ex.id !== exerciseId));
+    setExercises((prev) => prev.filter((ex) => ex.id !== exerciseId));
   };
 
   const addSet = (exerciseId) => {
-    setExercises(prev => prev.map(ex => 
-      ex.id === exerciseId 
-        ? { ...ex, sets: [...ex.sets, { reps: 0, weight: 0, duration: 0 }] }
-        : ex
-    ));
+    setExercises((prev) =>
+      prev.map((ex) =>
+        ex.id === exerciseId
+          ? { ...ex, sets: [...ex.sets, { reps: 0, weight: 0, duration: 0 }] }
+          : ex
+      )
+    );
   };
 
   const updateSet = (exerciseId, setIndex, field, value) => {
-    const parsed = field === 'weight'
-      ? parseFloat(String(value).replace(',', '.'))
-      : parseInt(value, 10);
+    const parsed =
+      field === 'weight'
+        ? parseFloat(String(value).replace(',', '.'))
+        : parseInt(value, 10);
 
-    setExercises(prev => prev.map(ex =>
-      ex.id === exerciseId
-        ? {
-            ...ex,
-            sets: ex.sets.map((set, idx) =>
-              idx === setIndex ? {
-                ...set,
-                [field]: Math.max(0, parsed || 0) // Valeur minimale 0
-              } : set
-            )
-          }
-        : ex
-    ));
+    setExercises((prev) =>
+      prev.map((ex) =>
+        ex.id === exerciseId
+          ? {
+              ...ex,
+              sets: ex.sets.map((set, idx) =>
+                idx === setIndex
+                  ? {
+                      ...set,
+                      [field]: Math.max(0, parsed || 0), // Valeur minimale 0
+                    }
+                  : set
+              ),
+            }
+          : ex
+      )
+    );
   };
 
   const removeSet = (exerciseId, setIndex) => {
-    setExercises(prev => prev.map(ex => 
-      ex.id === exerciseId 
-        ? { ...ex, sets: ex.sets.filter((_, idx) => idx !== setIndex) }
-        : ex
-    ));
+    setExercises((prev) =>
+      prev.map((ex) =>
+        ex.id === exerciseId
+          ? { ...ex, sets: ex.sets.filter((_, idx) => idx !== setIndex) }
+          : ex
+      )
+    );
   };
 
   const clearExercises = () => {
     setExercises([]);
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    save(STORAGE_KEYS.CURRENT_WORKOUT, { ...saved, exercises: [] });
   };
 
   const setExercisesFromWorkout = (workoutExercises) => {
     setExercises(workoutExercises);
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    save(STORAGE_KEYS.CURRENT_WORKOUT, {
+      ...saved,
+      exercises: workoutExercises,
+    });
   };
+
+  useEffect(() => {
+    const saved = load(STORAGE_KEYS.CURRENT_WORKOUT, {});
+    save(STORAGE_KEYS.CURRENT_WORKOUT, { ...saved, exercises });
+  }, [exercises]);
 
   return {
     exercises,
@@ -85,6 +114,6 @@ export const useExercises = () => {
     updateSet,
     removeSet,
     clearExercises,
-    setExercisesFromWorkout
+    setExercisesFromWorkout,
   };
-}; 
+};

--- a/src/hooks/useWorkoutLogic.js
+++ b/src/hooks/useWorkoutLogic.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { createWorkout } from '../utils/workoutUtils';
+import { STORAGE_KEYS } from '../constants';
 
 export default function useWorkoutLogic({
   exercises,
@@ -24,17 +25,27 @@ export default function useWorkoutLogic({
   showToastMsg,
   t,
   addWorkoutXP,
-  workouts
+  workouts,
 }) {
   // Ajout d'un exercice à la séance
-  const addExerciseToWorkout = useCallback((exerciseName, muscleGroup = null) => {
-    // S'assurer qu'on n'est pas en mode édition quand on ajoute un exercice
-    setSelectedWorkout(null);
-    addExercise(exerciseName, muscleGroup);
-    setShowAddExercise(false);
-    setSelectedMuscleGroup(null);
-    showToastMsg(t('exercise_added'));
-  }, [addExercise, setShowAddExercise, setSelectedMuscleGroup, setSelectedWorkout, showToastMsg, t]);
+  const addExerciseToWorkout = useCallback(
+    (exerciseName, muscleGroup = null) => {
+      // S'assurer qu'on n'est pas en mode édition quand on ajoute un exercice
+      setSelectedWorkout(null);
+      addExercise(exerciseName, muscleGroup);
+      setShowAddExercise(false);
+      setSelectedMuscleGroup(null);
+      showToastMsg(t('exercise_added'));
+    },
+    [
+      addExercise,
+      setShowAddExercise,
+      setSelectedMuscleGroup,
+      setSelectedWorkout,
+      showToastMsg,
+      t,
+    ]
+  );
 
   // Sauvegarde d'une séance
   const saveWorkout = useCallback(async () => {
@@ -42,31 +53,38 @@ export default function useWorkoutLogic({
       showToastMsg(t('no_exercises_to_save'), 'error');
       return;
     }
-    
+
     let duration = 30;
     if (startTime && endTime) {
       const start = new Date(`2000-01-01T${startTime}`);
       const end = new Date(`2000-01-01T${endTime}`);
       duration = Math.round((end - start) / (1000 * 60));
     }
-    
+
     const workout = createWorkout(
       exercises,
       selectedDate,
       duration,
-      selectedWorkout && typeof selectedWorkout.id === 'string' ? selectedWorkout.id : undefined,
+      selectedWorkout && typeof selectedWorkout.id === 'string'
+        ? selectedWorkout.id
+        : undefined,
       startTime,
       endTime
     );
-    
+
     if (!workout) {
       showToastMsg(t('workout_creation_error'), 'error');
       return;
     }
-    
+
     try {
       // Vérifier si on est vraiment en mode édition avec un workout valide
-      if (selectedWorkout && selectedWorkout.id && typeof selectedWorkout.id === 'string' && selectedWorkout.id.length > 0) {
+      if (
+        selectedWorkout &&
+        selectedWorkout.id &&
+        typeof selectedWorkout.id === 'string' &&
+        selectedWorkout.id.length > 0
+      ) {
         await updateWorkout(selectedWorkout.id, workout);
         showToastMsg(t('workout_updated'));
       } else {
@@ -78,68 +96,117 @@ export default function useWorkoutLogic({
             const previousWorkouts = workouts.slice(-5); // Derniers 5 workouts pour le calcul du streak
             const result = await addWorkoutXP(workout, previousWorkouts);
             if (result && result.levelUp) {
-              showToastMsg(`🎉 Niveau ${result.newLevel} atteint ! ${result.newLevelName}`, 'success');
+              showToastMsg(
+                `🎉 Niveau ${result.newLevel} atteint ! ${result.newLevelName}`,
+                'success'
+              );
             } else if (result && result.streakIncreased) {
-              showToastMsg(`🔥 Streak +1 ! ${result.newStreak} jours !`, 'success');
+              showToastMsg(
+                `🔥 Streak +1 ! ${result.newStreak} jours !`,
+                'success'
+              );
             } else {
-              showToastMsg(`+${result?.xpGained || 0} XP gagné ! 💪`, 'success');
+              showToastMsg(
+                `+${result?.xpGained || 0} XP gagné ! 💪`,
+                'success'
+              );
             }
           } catch (error) {
-            console.error('Erreur lors de l\'ajout d\'XP:', error);
+            console.error("Erreur lors de l'ajout d'XP:", error);
             // Ne pas bloquer la sauvegarde si l'XP échoue
           }
         }
         showToastMsg(t('workout_saved'));
       }
-      
+
       // Nettoyer le formulaire seulement si la sauvegarde réussit
       clearExercises();
       setStartTime('');
       setEndTime('');
       setSelectedWorkout(null);
       setShowWorkoutDetail(false);
+      localStorage.removeItem(STORAGE_KEYS.CURRENT_WORKOUT);
     } catch (error) {
       console.error('Erreur lors de la sauvegarde:', error);
       showToastMsg(t('workout_save_error'), 'error');
     }
-  }, [exercises, selectedDate, startTime, endTime, selectedWorkout, addWorkout, updateWorkout, clearExercises, setStartTime, setEndTime, setSelectedWorkout, setShowWorkoutDetail, showToastMsg, t, addWorkoutXP, workouts]);
+  }, [
+    exercises,
+    selectedDate,
+    startTime,
+    endTime,
+    selectedWorkout,
+    addWorkout,
+    updateWorkout,
+    clearExercises,
+    setStartTime,
+    setEndTime,
+    setSelectedWorkout,
+    setShowWorkoutDetail,
+    showToastMsg,
+    t,
+    addWorkoutXP,
+    workouts,
+  ]);
 
   // Ouvre le détail d'une séance
-  const openWorkoutDetail = useCallback((workout) => {
-    setSelectedWorkout(workout);
-    setShowWorkoutDetail(true);
-  }, [setSelectedWorkout, setShowWorkoutDetail]);
+  const openWorkoutDetail = useCallback(
+    (workout) => {
+      setSelectedWorkout(workout);
+      setShowWorkoutDetail(true);
+    },
+    [setSelectedWorkout, setShowWorkoutDetail]
+  );
 
   // Prépare l'édition d'une séance
-  const handleEditWorkout = useCallback((workout) => {
-    setSelectedWorkout(workout);
-    setSelectedDate(workout.date);
-    setStartTime(workout.startTime);
-    setEndTime(workout.endTime);
-    setExercisesFromWorkout(workout.exercises);
-    setActiveTab('workout');
-  }, [setSelectedWorkout, setSelectedDate, setStartTime, setEndTime, setExercisesFromWorkout, setActiveTab]);
+  const handleEditWorkout = useCallback(
+    (workout) => {
+      setSelectedWorkout(workout);
+      setSelectedDate(workout.date);
+      setStartTime(workout.startTime);
+      setEndTime(workout.endTime);
+      setExercisesFromWorkout(workout.exercises);
+      setActiveTab('workout');
+    },
+    [
+      setSelectedWorkout,
+      setSelectedDate,
+      setStartTime,
+      setEndTime,
+      setExercisesFromWorkout,
+      setActiveTab,
+    ]
+  );
 
   // Suppression d'une séance
-  const handleDeleteWorkout = useCallback(async (workoutId) => {
-    if (typeof workoutId === 'string' && window.confirm(t('confirm_delete_workout'))) {
-      try {
-        await deleteWorkout(workoutId);
-        setShowWorkoutDetail(false); // Fermer la modale après suppression
-        showToastMsg(t('workout_deleted'), 'success');
-      } catch (e) {
-        showToastMsg(t('error_delete'), 'error');
+  const handleDeleteWorkout = useCallback(
+    async (workoutId) => {
+      if (
+        typeof workoutId === 'string' &&
+        window.confirm(t('confirm_delete_workout'))
+      ) {
+        try {
+          await deleteWorkout(workoutId);
+          setShowWorkoutDetail(false); // Fermer la modale après suppression
+          showToastMsg(t('workout_deleted'), 'success');
+        } catch (e) {
+          showToastMsg(t('error_delete'), 'error');
+        }
+      } else {
+        showToastMsg(
+          'Suppression impossible : id de séance invalide.',
+          'error'
+        );
       }
-    } else {
-      showToastMsg('Suppression impossible : id de séance invalide.', 'error');
-    }
-  }, [deleteWorkout, setShowWorkoutDetail, showToastMsg, t]);
+    },
+    [deleteWorkout, setShowWorkoutDetail, showToastMsg, t]
+  );
 
   return {
     addExerciseToWorkout,
     saveWorkout,
     openWorkoutDetail,
     handleEditWorkout,
-    handleDeleteWorkout
+    handleDeleteWorkout,
   };
-} 
+}


### PR DESCRIPTION
## Summary
- add `CURRENT_WORKOUT` key
- persist exercises and workout details in localStorage
- clear stored workout when session saved

## Testing
- `npx prettier -w src/constants/storageKeys.js src/hooks/useExercises.js src/hooks/useAppState.js src/hooks/useWorkoutLogic.js`
- `npx eslint src/constants/storageKeys.js src/hooks/useExercises.js src/hooks/useAppState.js src/hooks/useWorkoutLogic.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68814cfdb5cc8331bdbe46caed03bb8e