### PR TITLE
Add exercise removal from sessions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -74,7 +74,16 @@ function App() {
 
   // Hooks personnalisés
   const { workouts, addWorkout, updateWorkout, deleteWorkout, getWorkoutForDate, getStats } = useWorkouts(user);
-  const { exercises, addExercise, addSet, updateSet, removeSet, clearExercises, setExercisesFromWorkout } = useExercises();
+  const {
+    exercises,
+    addExercise,
+    removeExercise,
+    addSet,
+    updateSet,
+    removeSet,
+    clearExercises,
+    setExercisesFromWorkout,
+  } = useExercises();
   const { addWorkoutXP, addBadgeUnlockXP, addFriendXP, addChallengeSendXP, addChallengeWinXP } = useExperience(user);
   const { challenges } = useChallenges(user, addChallengeSendXP, addChallengeWinXP);
   const { friends } = useFriends(user, addFriendXP);
@@ -92,6 +101,7 @@ function App() {
     updateWorkout,
     deleteWorkout,
     addExercise,
+    removeExercise,
     clearExercises,
     setStartTime,
     setEndTime,
@@ -108,7 +118,14 @@ function App() {
     workouts
   });
 
-  const { addExerciseToWorkout, saveWorkout, openWorkoutDetail, handleEditWorkout, handleDeleteWorkout } = workoutLogic;
+  const {
+    addExerciseToWorkout,
+    removeExerciseFromWorkout,
+    saveWorkout,
+    openWorkoutDetail,
+    handleEditWorkout,
+    handleDeleteWorkout,
+  } = workoutLogic;
 
   // Configuration des onglets pour la navigation
   const tabs = [
@@ -215,6 +232,7 @@ function App() {
               selectedMuscleGroup={selectedMuscleGroup}
               setSelectedMuscleGroup={setSelectedMuscleGroup}
               addExerciseToWorkout={addExerciseToWorkout}
+              removeExerciseFromWorkout={removeExerciseFromWorkout}
             />
           </PageTransition>
 

--- a/src/components/Workout/WorkoutList/WorkoutList.jsx
+++ b/src/components/Workout/WorkoutList/WorkoutList.jsx
@@ -55,6 +55,7 @@ function WorkoutList({
   selectedMuscleGroup,
   setSelectedMuscleGroup,
   addExerciseToWorkout,
+  removeExerciseFromWorkout,
   user,
   className = '',
 }) {
@@ -200,7 +201,19 @@ function WorkoutList({
                     </span>
                   </div>
                 </div>
-                <IconButton icon={Plus} onClick={() => addSet(exercise.id)} className="bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white shadow-md hover:shadow-lg" />
+                <div className="flex items-center space-x-2">
+                  <IconButton
+                    icon={Plus}
+                    onClick={() => addSet(exercise.id)}
+                    className="bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white shadow-md hover:shadow-lg"
+                  />
+                  <IconButton
+                    icon={X}
+                    onClick={() => removeExerciseFromWorkout(exercise.id)}
+                    className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                    title={t('remove')}
+                  />
+                </div>
               </div>
 
               <div className="space-y-3">
@@ -617,6 +630,7 @@ WorkoutList.propTypes = {
   selectedMuscleGroup: PropTypes.string,
   setSelectedMuscleGroup: PropTypes.func,
   addExerciseToWorkout: PropTypes.func,
+  removeExerciseFromWorkout: PropTypes.func,
   user: PropTypes.object, // Added user prop type
   className: PropTypes.string,
 };

--- a/src/hooks/useWorkoutLogic.js
+++ b/src/hooks/useWorkoutLogic.js
@@ -12,6 +12,7 @@ export default function useWorkoutLogic({
   updateWorkout,
   deleteWorkout,
   addExercise,
+  removeExercise,
   clearExercises,
   setStartTime,
   setEndTime,
@@ -45,6 +46,15 @@ export default function useWorkoutLogic({
       showToastMsg,
       t,
     ]
+  );
+
+  // Suppression d'un exercice de la séance
+  const removeExerciseFromWorkout = useCallback(
+    (exerciseId) => {
+      removeExercise(exerciseId);
+      showToastMsg(t('exercise_removed'));
+    },
+    [removeExercise, showToastMsg, t]
   );
 
   // Sauvegarde d'une séance
@@ -204,6 +214,7 @@ export default function useWorkoutLogic({
 
   return {
     addExerciseToWorkout,
+    removeExerciseFromWorkout,
     saveWorkout,
     openWorkoutDetail,
     handleEditWorkout,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -33,6 +33,8 @@ const resources = {
       "workout_updated": "Séance modifiée avec succès ! 💪",
       "workout_deleted": "Séance supprimée !",
       "exercise_added": "Exercice ajouté à la séance !",
+      "exercise_removed": "Exercice supprimé de la séance !",
+      "remove": "Supprimer",
       "confirm_delete_workout": "Êtes-vous sûr de vouloir supprimer cette séance ? 🗑️",
       "error_update": "Erreur lors de la modification de la séance.",
       "error_delete": "Erreur lors de la suppression de la séance.",

--- a/src/tests/hooks/useExercises.test.js
+++ b/src/tests/hooks/useExercises.test.js
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { useExercises } from '../../hooks/useExercises';
+
+describe('useExercises', () => {
+  it('should add and remove an exercise', () => {
+    const { result } = renderHook(() => useExercises());
+
+    act(() => {
+      result.current.addExercise('Pompes');
+    });
+    expect(result.current.exercises.length).toBe(1);
+
+    const id = result.current.exercises[0].id;
+    act(() => {
+      result.current.removeExercise(id);
+    });
+
+    expect(result.current.exercises.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- allow exercises to be removed from a workout
- show delete exercise button in workout list
- add FR translations for removing exercises
- expose removeExerciseFromWorkout in logic hooks and pass to components
- test useExercises hook

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688150bfbb64833191b22cbf85a423ca