### PR TITLE
Fix date display by parsing without timezone

### DIFF
--- a/src/components/CalendarView/CalendarView.jsx
+++ b/src/components/CalendarView/CalendarView.jsx
@@ -64,7 +64,9 @@ const CalendarView = ({
   }
 
   const [openWeeks, setOpenWeeks] = useState([]);
-  const sortedWorkouts = [...workouts].sort((a, b) => new Date(b.date) - new Date(a.date));
+  const sortedWorkouts = [...workouts].sort(
+    (a, b) => parseLocalDate(b.date) - parseLocalDate(a.date)
+  );
   const weeks = groupWorkoutsByWeek(workouts);
   const dateLocale = i18n.language === 'fr' ? 'fr-FR' : undefined;
 
@@ -159,7 +161,7 @@ const CalendarView = ({
           </div>
           <p className="text-3xl font-bold text-blue-900">
             {workouts.filter(w => {
-              const workoutDate = new Date(w.date);
+              const workoutDate = parseLocalDate(w.date);
               const today = new Date();
               const weekStart = new Date(today);
               weekStart.setDate(today.getDate() - today.getDay());
@@ -190,10 +192,10 @@ const CalendarView = ({
           <span>{t('last_sessions')}</span>
         </h3>
         <div className="space-y-4">
-          {sortedWorkouts.slice(0, 5).map((workout) => (
-            <div key={workout.id} className="flex justify-between items-center py-4 px-6 bg-gray-100 rounded-2xl border border-gray-200 hover:shadow-md transition-shadow duration-200">
-              <div>
-                <p className="font-bold text-gray-800">{new Date(workout.date).toLocaleDateString(dateLocale)}</p>
+            {sortedWorkouts.slice(0, 5).map((workout) => (
+              <div key={workout.id} className="flex justify-between items-center py-4 px-6 bg-gray-100 rounded-2xl border border-gray-200 hover:shadow-md transition-shadow duration-200">
+                <div>
+                  <p className="font-bold text-gray-800">{parseLocalDate(workout.date).toLocaleDateString(dateLocale)}</p>
                 <p className="text-sm text-gray-600">
                   {workout.exercises.length} {t('exercises')} • {workout.totalSets} {t('sets')}
                   {workout.startTime && (
@@ -245,15 +247,15 @@ const CalendarView = ({
                 </button>
                 {isOpen && (
                   <div className="space-y-3 mt-2">
-                    {weekWorkouts
-                      .sort((a, b) => new Date(b.date) - new Date(a.date))
-                      .map((w) => (
-                        <div
-                          key={w.id}
-                          className="bg-white rounded-xl shadow p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between border border-gray-100"
-                        >
-                          <div>
-                            <div className="font-bold text-lg text-gray-800">{new Date(w.date).toLocaleDateString(dateLocale)}</div>
+                      {weekWorkouts
+                        .sort((a, b) => parseLocalDate(b.date) - parseLocalDate(a.date))
+                        .map((w) => (
+                          <div
+                            key={w.id}
+                            className="bg-white rounded-xl shadow p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between border border-gray-100"
+                          >
+                            <div>
+                              <div className="font-bold text-lg text-gray-800">{parseLocalDate(w.date).toLocaleDateString(dateLocale)}</div>
                             <div className="text-sm text-gray-500">
                               {w.exercises.length} {t('exercises')}, {w.totalSets} {t('sets')}, {w.totalReps}{' '}
                               {t('reps')}, {w.totalWeight} {t('kg')}

--- a/src/hooks/useBadges.js
+++ b/src/hooks/useBadges.js
@@ -3,6 +3,7 @@ import { BADGE_TYPES } from '../constants/badges';
 import { saveUserBadges } from '../utils/firebase';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../utils/firebase';
+import { parseLocalDate } from '../utils/workoutUtils';
 
 // Fonction pour calculer les badges d'un utilisateur
 export function calculateUserBadges(workouts = [], challenges = [], user) {
@@ -18,13 +19,15 @@ export function calculateUserBadges(workouts = [], challenges = [], user) {
   }
 
   // Badges de séries d'entraînement
-  const sortedWorkouts = [...workouts].sort((a, b) => new Date(a.date) - new Date(b.date));
+  const sortedWorkouts = [...workouts].sort(
+    (a, b) => parseLocalDate(a.date) - parseLocalDate(b.date)
+  );
   let currentStreak = 1;
   let maxStreak = 1;
 
   for (let i = 1; i < sortedWorkouts.length; i++) {
-    const prevDate = new Date(sortedWorkouts[i - 1].date);
-    const currDate = new Date(sortedWorkouts[i].date);
+    const prevDate = parseLocalDate(sortedWorkouts[i - 1].date);
+    const currDate = parseLocalDate(sortedWorkouts[i].date);
     const dayDiff = Math.floor((currDate - prevDate) / (1000 * 60 * 60 * 24));
 
     if (dayDiff === 1) {
@@ -75,7 +78,7 @@ export function calculateUserBadges(workouts = [], challenges = [], user) {
   // Badges de régularité hebdomadaire
   const oneWeekAgo = new Date();
   oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-  const recentWorkouts = workouts.filter(w => new Date(w.date) >= oneWeekAgo);
+  const recentWorkouts = workouts.filter(w => parseLocalDate(w.date) >= oneWeekAgo);
   
   if (recentWorkouts.length >= 3) badges.push(BADGE_TYPES.WEEKLY_3);
   if (recentWorkouts.length >= 5) badges.push(BADGE_TYPES.WEEKLY_5);
@@ -84,7 +87,7 @@ export function calculateUserBadges(workouts = [], challenges = [], user) {
   // Badges de régularité mensuelle
   const oneMonthAgo = new Date();
   oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-  const monthlyWorkouts = workouts.filter(w => new Date(w.date) >= oneMonthAgo);
+  const monthlyWorkouts = workouts.filter(w => parseLocalDate(w.date) >= oneMonthAgo);
   
   if (monthlyWorkouts.length >= 10) badges.push(BADGE_TYPES.MONTHLY_10);
   if (monthlyWorkouts.length >= 20) badges.push(BADGE_TYPES.MONTHLY_20);
@@ -117,19 +120,19 @@ export function calculateUserBadges(workouts = [], challenges = [], user) {
 
   // Badges de temps
   const earlyWorkouts = workouts.filter(w => {
-    const hour = new Date(w.date).getHours();
+    const hour = parseLocalDate(w.date).getHours();
     return hour < 8;
   });
   if (earlyWorkouts.length >= 5) badges.push(BADGE_TYPES.EARLY_BIRD);
 
   const nightWorkouts = workouts.filter(w => {
-    const hour = new Date(w.date).getHours();
+    const hour = parseLocalDate(w.date).getHours();
     return hour >= 22;
   });
   if (nightWorkouts.length >= 5) badges.push(BADGE_TYPES.NIGHT_OWL);
 
   const weekendWorkouts = workouts.filter(w => {
-    const day = new Date(w.date).getDay();
+    const day = parseLocalDate(w.date).getDay();
     return day === 0 || day === 6;
   });
   if (weekendWorkouts.length >= 10) badges.push(BADGE_TYPES.WEEKEND_WARRIOR);

--- a/src/hooks/useChallenges.js
+++ b/src/hooks/useChallenges.js
@@ -5,7 +5,7 @@ import {
   updateChallengeInFirebase,
   deleteChallengeFromFirebase
 } from '../utils/firebase';
-import { getWorkoutsForDateRange } from '../utils/workoutUtils';
+import { getWorkoutsForDateRange, parseLocalDate } from '../utils/workoutUtils';
 import { useWorkouts } from './useWorkouts';
 
 export const useChallenges = (user, addChallengeSendXP, addChallengeWinXP) => {
@@ -111,11 +111,11 @@ export const useChallenges = (user, addChallengeSendXP, addChallengeWinXP) => {
           return filteredWorkouts.length;
         case 'duration':
           return filteredWorkouts.reduce((total, workout) => total + (workout.duration || 0), 0);
-        case 'streak': {
-          // S'assurer que les dates de workout sont bien des objets Date
-          const sortedDates = filteredWorkouts
-            .map(w => typeof w.date === 'string' ? new Date(w.date) : w.date)
-            .sort((a, b) => a - b);
+          case 'streak': {
+            // S'assurer que les dates de workout sont bien des objets Date
+            const sortedDates = filteredWorkouts
+              .map(w => parseLocalDate(w.date))
+              .sort((a, b) => a - b);
           let maxStreak = 0;
           let currentStreak = 0;
           let lastDate = null;

--- a/src/hooks/useExperience.js
+++ b/src/hooks/useExperience.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { doc, onSnapshot, updateDoc } from 'firebase/firestore';
 import { db } from '../utils/firebase';
+import { parseLocalDate } from '../utils/workoutUtils';
 
 // XP nécessaire pour chaque niveau (progression exponentielle)
 function xpRequired(level) {
@@ -61,12 +62,12 @@ function calculateWorkoutXP(workout, previousWorkouts = []) {
   xp += uniqueExercises * XP_REWARDS.WORKOUT.EXERCISE_BONUS;
   
   // Bonus streak si séance la veille
-  if (previousWorkouts.length > 0) {
-    const lastWorkoutDate = new Date(previousWorkouts[0].date);
-    const currentWorkoutDate = new Date(workout.date);
-    const daysDiff = Math.floor((currentWorkoutDate - lastWorkoutDate) / (1000 * 60 * 60 * 24));
-    if (daysDiff === 1) xp += XP_REWARDS.WORKOUT.STREAK_BONUS;
-  }
+    if (previousWorkouts.length > 0) {
+      const lastWorkoutDate = parseLocalDate(previousWorkouts[0].date);
+      const currentWorkoutDate = parseLocalDate(workout.date);
+      const daysDiff = Math.floor((currentWorkoutDate - lastWorkoutDate) / (1000 * 60 * 60 * 24));
+      if (daysDiff === 1) xp += XP_REWARDS.WORKOUT.STREAK_BONUS;
+    }
   
   // Bonus séance parfaite (tous les exercices ont des sets complétés)
   const allExercisesCompleted = workout.exercises?.every(ex => 
@@ -148,12 +149,12 @@ export const useExperience = (user) => {
     // Calcul streak
     let newStreak = 1;
     let streakIncreased = false;
-    if (previousWorkouts.length > 0) {
-      const lastWorkoutDate = new Date(previousWorkouts[0].date);
-      const currentWorkoutDate = new Date(workout.date);
-      const daysDiff = Math.floor((currentWorkoutDate - lastWorkoutDate) / (1000 * 60 * 60 * 24));
-      if (daysDiff === 1) {
-        newStreak = currentExp.streak + 1;
+      if (previousWorkouts.length > 0) {
+        const lastWorkoutDate = parseLocalDate(previousWorkouts[0].date);
+        const currentWorkoutDate = parseLocalDate(workout.date);
+        const daysDiff = Math.floor((currentWorkoutDate - lastWorkoutDate) / (1000 * 60 * 60 * 24));
+        if (daysDiff === 1) {
+          newStreak = currentExp.streak + 1;
         streakIncreased = true;
       } else if (daysDiff === 0) {
         newStreak = currentExp.streak; // même jour, ne pas incrémenter

--- a/src/utils/badges.js
+++ b/src/utils/badges.js
@@ -1,4 +1,6 @@
 // Système de badges pour récompenser les utilisateurs
+import { parseLocalDate } from './workoutUtils';
+
 export const badges = {
   // Badges de séances
   firstWorkout: {
@@ -158,13 +160,19 @@ export const calculateBadgeStats = (workouts, challenges, friends) => {
   }
 
   // Calcul du streak actuel
-  const sortedWorkouts = [...workouts].sort((a, b) => new Date(b.date) - new Date(a.date));
+  const sortedWorkouts = [...workouts].sort(
+    (a, b) => parseLocalDate(b.date) - parseLocalDate(a.date)
+  );
   let currentStreak = 0;
   let lastDate = null;
 
   for (let i = 0; i < sortedWorkouts.length; i++) {
-    const workoutDate = new Date(sortedWorkouts[i].date);
-    const workoutDay = new Date(workoutDate.getFullYear(), workoutDate.getMonth(), workoutDate.getDate());
+    const workoutDate = parseLocalDate(sortedWorkouts[i].date);
+    const workoutDay = new Date(
+      workoutDate.getFullYear(),
+      workoutDate.getMonth(),
+      workoutDate.getDate()
+    );
     
     if (!lastDate || (lastDate - workoutDay) / (1000 * 60 * 60 * 24) === 1) {
       currentStreak++;
@@ -179,12 +187,12 @@ export const calculateBadgeStats = (workouts, challenges, friends) => {
   const maxCalories = Math.max(...workouts.map(w => w.calories || 0));
   
   const earlyWorkouts = workouts.filter(w => {
-    const hour = new Date(w.date).getHours();
+    const hour = parseLocalDate(w.date).getHours();
     return hour < 7;
   }).length;
 
   const lateWorkouts = workouts.filter(w => {
-    const hour = new Date(w.date).getHours();
+    const hour = parseLocalDate(w.date).getHours();
     return hour >= 22;
   }).length;
 

--- a/src/utils/leaderboardUtils.js
+++ b/src/utils/leaderboardUtils.js
@@ -1,5 +1,6 @@
 // Utilitaires pour le leaderboard avancé
 import { PERIODS, METRICS, ALLOWED_EXERCISES } from '../constants/leaderboard';
+import { parseLocalDate } from './workoutUtils';
 
 // Obtenir la date de début selon la période
 export function getStartDate(period) {
@@ -29,7 +30,7 @@ export function getStartDate(period) {
 export function filterWorkoutsByPeriod(workouts, period) {
   const startDate = getStartDate(period);
   return workouts.filter(workout => {
-    const workoutDate = new Date(workout.date);
+    const workoutDate = parseLocalDate(workout.date);
     return workoutDate >= startDate;
   });
 }

--- a/src/utils/workoutUtils.js
+++ b/src/utils/workoutUtils.js
@@ -180,7 +180,7 @@ export function getWorkoutsForDateRange(workouts, startDate, endDate) {
   if (!workouts || !Array.isArray(workouts)) return [];
   
   return workouts.filter(workout => {
-    const workoutDate = new Date(workout.date);
+    const workoutDate = parseLocalDate(workout.date);
     return workoutDate >= startDate && workoutDate <= endDate;
   });
 }
@@ -211,9 +211,11 @@ export function cleanWorkoutForFirestore(workout) {
 
 export function getLastExerciseWeight(workouts, exerciseName, beforeDate = null) {
   if (!Array.isArray(workouts) || !exerciseName) return null;
-  const sorted = [...workouts].sort((a, b) => new Date(b.date) - new Date(a.date));
+  const sorted = [...workouts].sort(
+    (a, b) => parseLocalDate(b.date) - parseLocalDate(a.date)
+  );
   for (const workout of sorted) {
-    if (beforeDate && new Date(workout.date) >= new Date(beforeDate)) continue;
+    if (beforeDate && parseLocalDate(workout.date) >= parseLocalDate(beforeDate)) continue;
     const exercise = workout.exercises?.find(
       ex => ex.name && ex.name.toLowerCase() === exerciseName.toLowerCase()
     );


### PR DESCRIPTION
## Summary
- use `parseLocalDate` in CalendarView and other utilities
- fix date calculations in hooks and utils
- ensure timezone offsets don't shift displayed workout dates

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688159bb4c808331bd67470b92929b4d