### PR TITLE
Add component tests and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,38 +2,44 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18'
-        cache: 'npm'
-    
-    - name: Install dependencies
-      run: npm ci
-    
-    - name: Run tests
-      run: npm test -- --coverage --watchAll=false
-    
-    - name: Run linting
-      run: npm run lint
-    
-    - name: Build project
-      run: npm run build
-    
-    - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage/lcov.info
-        flags: unittests
-        name: codecov-umbrella 
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --coverage --watchAll=false
+
+      - name: Run linting
+        run: npm run lint
+
+      - name: Check formatting
+        run: npx prettier --check .
+
+      - name: Audit packages
+        run: npm audit --audit-level=high
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella

--- a/src/components/StreakCounter.jsx
+++ b/src/components/StreakCounter.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, memo } from 'react';
 import { Flame } from 'lucide-react';
 import PropTypes from 'prop-types';
 
-function getStreakMessage(streak) {
+export function getStreakMessage(streak) {
   if (streak >= 100) return '🔥 LÉGENDAIRE !';
   if (streak >= 30) return '🔥 INCROYABLE !';
   if (streak >= 7) return '🔥 EN FEU !';
@@ -31,11 +31,28 @@ const StreakCounter = ({ streak, className = '' }) => {
   }, [streak, displayStreak]);
 
   return (
-    <div className={`flex items-center space-x-2 bg-white/70 rounded-lg px-2 py-1 border border-gray-100 shadow-sm ${className}`} style={{ minWidth: 0 }}>
-      <Flame className="h-5 w-5 text-orange-300 mr-1" style={{ minWidth: 20 }} />
-      <span className="text-base font-semibold text-gray-700" style={{ letterSpacing: 0.5 }}>{displayStreak} <span className="text-xs font-normal text-gray-400">jours</span></span>
+    <div
+      className={`flex items-center space-x-2 bg-white/70 rounded-lg px-2 py-1 border border-gray-100 shadow-sm ${className}`}
+      style={{ minWidth: 0 }}
+    >
+      <Flame
+        className="h-5 w-5 text-orange-300 mr-1"
+        style={{ minWidth: 20 }}
+      />
+      <span
+        className="text-base font-semibold text-gray-700"
+        style={{ letterSpacing: 0.5 }}
+      >
+        {displayStreak}{' '}
+        <span className="text-xs font-normal text-gray-400">jours</span>
+      </span>
       {getStreakMessage(streak) && (
-        <span className="ml-2 text-xs text-orange-400 font-medium" style={{ whiteSpace: 'nowrap' }}>{getStreakMessage(streak)}</span>
+        <span
+          className="ml-2 text-xs text-orange-400 font-medium"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          {getStreakMessage(streak)}
+        </span>
       )}
     </div>
   );
@@ -43,7 +60,7 @@ const StreakCounter = ({ streak, className = '' }) => {
 
 StreakCounter.propTypes = {
   streak: PropTypes.number.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
-export default StreakCounter; 
+export default memo(StreakCounter);

--- a/src/tests/components/IconButton.test.js
+++ b/src/tests/components/IconButton.test.js
@@ -1,0 +1,15 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import { Flame } from 'lucide-react';
+import IconButton from '../../components/IconButton';
+
+describe('IconButton', () => {
+  it('renders icon and handles click', () => {
+    const handleClick = jest.fn();
+    render(<IconButton icon={Flame} onClick={handleClick} title="flame" />);
+    const btn = screen.getByTitle('flame');
+    fireEvent.click(btn);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(btn.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/src/tests/components/StreakCounter.test.js
+++ b/src/tests/components/StreakCounter.test.js
@@ -1,0 +1,25 @@
+import { render, act, screen } from '@testing-library/react';
+import StreakCounter, {
+  getStreakMessage,
+} from '../../components/StreakCounter';
+
+describe('StreakCounter', () => {
+  it('returns correct streak messages', () => {
+    expect(getStreakMessage(0)).toBe('');
+    expect(getStreakMessage(3)).toBe('🔥 CONTINUE !');
+    expect(getStreakMessage(7)).toBe('🔥 EN FEU !');
+    expect(getStreakMessage(30)).toBe('🔥 INCROYABLE !');
+    expect(getStreakMessage(100)).toBe('🔥 LÉGENDAIRE !');
+  });
+
+  it('animates streak increase', () => {
+    jest.useFakeTimers();
+    const { rerender } = render(<StreakCounter streak={1} />);
+    rerender(<StreakCounter streak={3} />);
+    act(() => {
+      jest.advanceTimersByTime(120);
+    });
+    expect(screen.getByText(/3/)).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap `StreakCounter` in `React.memo` and expose `getStreakMessage`
- add unit tests for `StreakCounter` and `IconButton`
- enforce prettier and npm audit in CI

## Testing
- `npm run lint`
- `npm test -- --coverage --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68816d28ad108331b730fe2059633acd