### PR TITLE
Add API key verification tests

### DIFF
--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -40,4 +40,18 @@ describe('Chatbot component', () => {
     expect(sendMessage).toHaveBeenCalledWith('Yo', null);
     await waitFor(() => expect(screen.getByPlaceholderText('Votre message...').value).toBe(''));
   });
+
+  it('uses API key from environment variables', () => {
+    const originalKey = process.env.REACT_APP_OPENAI_API_KEY;
+    process.env.REACT_APP_OPENAI_API_KEY = 'test-key';
+
+    const sendMessage = jest.fn();
+    useChatGPT.mockReturnValue({ messages: [], sendMessage });
+
+    render(<Chatbot workouts={[]} />);
+
+    expect(useChatGPT).toHaveBeenCalledWith('test-key');
+
+    process.env.REACT_APP_OPENAI_API_KEY = originalKey;
+  });
 });

--- a/src/tests/hooks/useChatGPT.test.js
+++ b/src/tests/hooks/useChatGPT.test.js
@@ -40,4 +40,23 @@ describe('useChatGPT', () => {
       { role: 'assistant', content: 'Bonjour' }
     ]);
   });
+
+  it('uses Authorization header with provided API key', async () => {
+    global.fetch.mockResolvedValue({ json: async () => ({ choices: [] }) });
+
+    const { result } = renderHook(() => useChatGPT('my-key'));
+
+    await act(async () => {
+      await result.current.sendMessage('Hello');
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-key'
+        })
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure Chatbot passes env API key to `useChatGPT`
- verify `useChatGPT` sends Authorization header when key is provided

## Testing
- `CI=true npx react-scripts test --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_68817196dab883319cbd8f00479afcdf