### PR TITLE
Fix session duplication when editing workouts

### DIFF
--- a/src/hooks/useWorkoutLogic.js
+++ b/src/hooks/useWorkoutLogic.js
@@ -75,7 +75,7 @@ export default function useWorkoutLogic({
       exercises,
       selectedDate,
       duration,
-      selectedWorkout && typeof selectedWorkout.id === 'string'
+      selectedWorkout && selectedWorkout.id != null
         ? selectedWorkout.id
         : undefined,
       startTime,
@@ -89,12 +89,7 @@ export default function useWorkoutLogic({
 
     try {
       // Vérifier si on est vraiment en mode édition avec un workout valide
-      if (
-        selectedWorkout &&
-        selectedWorkout.id &&
-        typeof selectedWorkout.id === 'string' &&
-        selectedWorkout.id.length > 0
-      ) {
+      if (selectedWorkout && selectedWorkout.id != null) {
         await updateWorkout(selectedWorkout.id, workout);
         showToastMsg(t('workout_updated'));
       } else {


### PR DESCRIPTION
## Summary
- prevent creating a new workout when editing an existing one with a numeric id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881805f2b988331b8f18624c0cb20cd