### PR TITLE
Add workout analytics to chatbot

### DIFF
--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -22,7 +22,7 @@ describe('Chatbot component', () => {
     await waitFor(() =>
       expect(sendMessage).toHaveBeenCalledWith(
         'Hello',
-        expect.stringContaining('Données récentes')
+        expect.stringContaining('Répartition')
       )
     );
   });

--- a/src/tests/utils/workoutUtils.test.js
+++ b/src/tests/utils/workoutUtils.test.js
@@ -9,7 +9,9 @@ import {
   getPreferredWorkoutTime,
   getAverageDurationByTime,
   getWorkoutsForDateRange,
-  cleanWorkoutForFirestore
+  cleanWorkoutForFirestore,
+  getMuscleGroupDistribution,
+  getWeightProgress
 } from '../../utils/workoutUtils';
 
 describe('workoutUtils', () => {
@@ -78,5 +80,23 @@ describe('workoutUtils', () => {
     expect(range).toHaveLength(1);
     const cleaned = cleanWorkoutForFirestore({ a: 1, b: null, c: { d: 2, e: undefined } });
     expect(cleaned).toEqual({ a: 1, c: { d: 2 } });
+  });
+
+  it('computes muscle group distribution', () => {
+    const workouts = [
+      { exercises: [{ type: 'jambes' }, { type: 'jambes' }] },
+      { exercises: [{ type: 'biceps' }] }
+    ];
+    const dist = getMuscleGroupDistribution(workouts);
+    expect(dist.jambes).toBeGreaterThan(dist.biceps);
+  });
+
+  it('calculates weight progress', () => {
+    const workouts = [
+      { date: '2024-01-01', exercises: [{ name: 'Squat', sets: [{ weight: 50 }] }] },
+      { date: '2024-01-10', exercises: [{ name: 'Squat', sets: [{ weight: 60 }] }] }
+    ];
+    const progress = getWeightProgress(workouts);
+    expect(progress.Squat).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary
- add helper functions `getMuscleGroupDistribution` and `getWeightProgress`
- enhance `Chatbot` to summarize all workouts using these helpers
- update unit tests for new behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881b755c5b88331a7078652347bc47e