### PR TITLE
Improve chatbot coaching mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Application moderne de suivi de séances de sport avec gamification avancée et 
 ### 🤖 Chatbot IA
 - **Mode sombre** : Interface adaptée aux thèmes clairs et foncés
 - **Tests dédiés** : Scénarios vérifiant le comportement du chatbot
+- **Coach virtuel** : Le chatbot répond toujours en tant que coach sportif
 
 ## 🏗️ Architecture
 

--- a/src/components/Chatbot/Chatbot.jsx
+++ b/src/components/Chatbot/Chatbot.jsx
@@ -30,10 +30,12 @@ const Chatbot = ({ workouts }) => {
 
   const handleSend = async () => {
     if (!input.trim()) return;
+    const base =
+      'Tu es mon coach sportif personnel. Sois motivant et adapte tes conseils à mon niveau.';
     const context =
       mode === 'advice'
-        ? `Tu es un coach sportif. Analyse mes séances précédentes. ${getSummary()} Donne-moi des conseils précis.`
-        : null;
+        ? `${base} Analyse mes séances précédentes. ${getSummary()} Donne-moi des conseils précis.`
+        : base;
     await sendMessage(input, context);
     setInput('');
   };

--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -27,7 +27,7 @@ describe('Chatbot component', () => {
     );
   });
 
-  it('sends message without context in free mode', async () => {
+  it('sends message with coach context in free mode', async () => {
     const sendMessage = jest.fn();
     useChatGPT.mockReturnValue({ messages: [], sendMessage });
 
@@ -37,7 +37,10 @@ describe('Chatbot component', () => {
     fireEvent.change(screen.getByPlaceholderText('Votre message...'), { target: { value: 'Yo' } });
     fireEvent.click(screen.getByText('Envoyer'));
 
-    expect(sendMessage).toHaveBeenCalledWith('Yo', null);
+    expect(sendMessage).toHaveBeenCalledWith(
+      'Yo',
+      expect.stringContaining('coach sportif')
+    );
     await waitFor(() => expect(screen.getByPlaceholderText('Votre message...').value).toBe(''));
   });
 


### PR DESCRIPTION
## Summary
- make the chatbot always answer as a personal coach
- update tests for new coach context
- document the chatbot coaching behaviour in the README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881bc49b0c4833189bf0f65dfa75716