### PR TITLE
Add workout session details to chatbot advice

### DIFF
--- a/src/components/Chatbot/Chatbot.jsx
+++ b/src/components/Chatbot/Chatbot.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import useChatGPT from '../../hooks/useChatGPT';
-import { getMuscleGroupDistribution, getWeightProgress } from '../../utils/workoutUtils';
+import { getMuscleGroupDistribution, getAverageWeights } from '../../utils/workoutUtils';
 
 const Chatbot = ({ workouts }) => {
   const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
@@ -19,13 +19,24 @@ const Chatbot = ({ workouts }) => {
       .map(([muscle, percent]) => `${muscle}:${percent}%`)
       .join(', ');
 
-    const progress = getWeightProgress(workouts);
-    const progressString = Object.entries(progress)
+    const weights = getAverageWeights(workouts);
+    const weightString = Object.entries(weights)
       .slice(0, 3)
-      .map(([name, diff]) => `${name}:${diff >= 0 ? '+' : ''}${diff}kg`)
+      .map(([name, avg]) => `${name}:${avg}kg`)
       .join(', ');
 
-    return `Répartition ${distString}. Progression poids ${progressString}`;
+    return `Répartition ${distString}. Poids ${weightString}`;
+  };
+
+  const getDetails = () => {
+    if (!workouts || workouts.length === 0) return '';
+    return workouts
+      .slice(-3)
+      .map(
+        w =>
+          `${w.date} - ${(w.exercises?.length || 0)} exercices - ${(w.duration || 0)}min`
+      )
+      .join('; ');
   };
 
   const handleSend = async () => {
@@ -34,7 +45,7 @@ const Chatbot = ({ workouts }) => {
       'Tu es mon coach sportif personnel. Sois motivant et adapte tes conseils à mon niveau.';
     const context =
       mode === 'advice'
-        ? `${base} Analyse mes séances précédentes. ${getSummary()} Donne-moi des conseils précis.`
+        ? `${base} Analyse mes séances précédentes. ${getSummary()} ${getDetails()} Donne-moi des conseils précis.`
         : base;
     await sendMessage(input, context);
     setInput('');

--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -25,6 +25,14 @@ describe('Chatbot component', () => {
         expect.stringContaining('Répartition')
       )
     );
+    expect(sendMessage).toHaveBeenCalledWith(
+      'Hello',
+      expect.stringContaining('Poids')
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      'Hello',
+      expect.stringContaining('2024-01-01')
+    );
   });
 
   it('sends message with coach context in free mode', async () => {

--- a/src/tests/utils/workoutUtils.test.js
+++ b/src/tests/utils/workoutUtils.test.js
@@ -11,7 +11,8 @@ import {
   getWorkoutsForDateRange,
   cleanWorkoutForFirestore,
   getMuscleGroupDistribution,
-  getWeightProgress
+  getWeightProgress,
+  getAverageWeights
 } from '../../utils/workoutUtils';
 
 describe('workoutUtils', () => {
@@ -98,5 +99,14 @@ describe('workoutUtils', () => {
     ];
     const progress = getWeightProgress(workouts);
     expect(progress.Squat).toBe(10);
+  });
+
+  it('computes average weights', () => {
+    const workouts = [
+      { exercises: [{ name: 'Bench', sets: [{ weight: 40 }, { weight: 50 }] }] },
+      { exercises: [{ name: 'Bench', sets: [{ weight: 60 }] }] }
+    ];
+    const weights = getAverageWeights(workouts);
+    expect(weights.Bench).toBe(50);
   });
 });

--- a/src/utils/workoutUtils.js
+++ b/src/utils/workoutUtils.js
@@ -271,3 +271,26 @@ export function getWeightProgress(workouts) {
   });
   return progress;
 }
+
+// Calcule le poids moyen par exercice sur l'ensemble des séances
+export function getAverageWeights(workouts) {
+  if (!Array.isArray(workouts)) return {};
+  const totals = {};
+  const counts = {};
+  workouts.forEach(w => {
+    w.exercises?.forEach(ex => {
+      if (Array.isArray(ex.sets)) {
+        ex.sets.forEach(set => {
+          const weight = parseFloat(set.weight) || 0;
+          totals[ex.name] = (totals[ex.name] || 0) + weight;
+          counts[ex.name] = (counts[ex.name] || 0) + 1;
+        });
+      }
+    });
+  });
+  const averages = {};
+  Object.keys(totals).forEach(name => {
+    averages[name] = Math.round(totals[name] / counts[name]);
+  });
+  return averages;
+}


### PR DESCRIPTION
## Summary
- provide brief details of the last sessions in Chatbot context
- calculate and show average weight instead of progress
- test average weight utility

## Testing
- `npm test --silent -- -w=1 --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6881be16b1108331b8e0c7f2391fef92