### PR TITLE
Add detailed weight info for Chatbot

### DIFF
--- a/src/components/Chatbot/Chatbot.jsx
+++ b/src/components/Chatbot/Chatbot.jsx
@@ -1,12 +1,16 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import useChatGPT from '../../hooks/useChatGPT';
-import { getMuscleGroupDistribution, getAverageWeights } from '../../utils/workoutUtils';
+import {
+  getMuscleGroupDistribution,
+  getAverageWeights,
+  getWorkoutWeightDetails,
+} from '../../utils/workoutUtils';
 
 const Chatbot = ({ workouts }) => {
   const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
-  console.log("REACT_APP_OPENAI_API_KEY:", apiKey);
-  console.log("REACT_APP_TEST_VAR:", process.env.REACT_APP_TEST_VAR);
+  console.log('REACT_APP_OPENAI_API_KEY:', apiKey);
+  console.log('REACT_APP_TEST_VAR:', process.env.REACT_APP_TEST_VAR);
   const { messages, sendMessage } = useChatGPT(apiKey);
   const [input, setInput] = useState('');
   const [mode, setMode] = useState('advice');
@@ -33,10 +37,15 @@ const Chatbot = ({ workouts }) => {
     return workouts
       .slice(-3)
       .map(
-        w =>
-          `${w.date} - ${(w.exercises?.length || 0)} exercices - ${(w.duration || 0)}min`
+        (w) =>
+          `${w.date} - ${w.exercises?.length || 0} exercices - ${w.duration || 0}min`
       )
       .join('; ');
+  };
+
+  const getWeightDetails = () => {
+    if (!workouts || workouts.length === 0) return '';
+    return getWorkoutWeightDetails(workouts.slice(-3));
   };
 
   const handleSend = async () => {
@@ -45,7 +54,7 @@ const Chatbot = ({ workouts }) => {
       'Tu es mon coach sportif personnel. Sois motivant et adapte tes conseils à mon niveau.';
     const context =
       mode === 'advice'
-        ? `${base} Analyse mes séances précédentes. ${getSummary()} ${getDetails()} Donne-moi des conseils précis.`
+        ? `${base} Analyse mes séances précédentes. ${getSummary()} ${getDetails()} ${getWeightDetails()} Donne-moi des conseils précis.`
         : base;
     await sendMessage(input, context);
     setInput('');
@@ -57,7 +66,7 @@ const Chatbot = ({ workouts }) => {
         <h2 className="text-3xl font-bold text-gray-800">Chatbot IA</h2>
         <select
           value={mode}
-          onChange={e => setMode(e.target.value)}
+          onChange={(e) => setMode(e.target.value)}
           className="border rounded p-1 text-lg"
         >
           <option value="advice">Recommandations</option>
@@ -66,7 +75,10 @@ const Chatbot = ({ workouts }) => {
       </div>
       <div className="border rounded-xl p-4 h-64 overflow-y-auto bg-white space-y-2 shadow-inner">
         {messages.map((m, i) => (
-          <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+          <div
+            key={i}
+            className={m.role === 'user' ? 'text-right' : 'text-left'}
+          >
             <span
               className={
                 m.role === 'user'
@@ -82,11 +94,14 @@ const Chatbot = ({ workouts }) => {
       <div className="flex space-x-2">
         <input
           value={input}
-          onChange={e => setInput(e.target.value)}
+          onChange={(e) => setInput(e.target.value)}
           className="flex-1 border rounded px-3 py-2 text-lg input-modern"
           placeholder="Votre message..."
         />
-        <button onClick={handleSend} className="btn-gradient text-white px-5 py-2 rounded text-lg">
+        <button
+          onClick={handleSend}
+          className="btn-gradient text-white px-5 py-2 rounded text-lg"
+        >
           Envoyer
         </button>
       </div>

--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -11,12 +11,18 @@ describe('Chatbot component', () => {
     useChatGPT.mockReturnValue({ messages: [], sendMessage });
 
     const workouts = [
-      { date: '2024-01-01', exercises: [{}, {}], duration: 30 }
+      {
+        date: '2024-01-01',
+        exercises: [{ name: 'Squat', sets: [{ weight: 100 }] }],
+        duration: 30,
+      },
     ];
 
     render(<Chatbot workouts={workouts} />);
 
-    fireEvent.change(screen.getByPlaceholderText('Votre message...'), { target: { value: 'Hello' } });
+    fireEvent.change(screen.getByPlaceholderText('Votre message...'), {
+      target: { value: 'Hello' },
+    });
     fireEvent.click(screen.getByText('Envoyer'));
 
     await waitFor(() =>
@@ -33,6 +39,10 @@ describe('Chatbot component', () => {
       'Hello',
       expect.stringContaining('2024-01-01')
     );
+    expect(sendMessage).toHaveBeenCalledWith(
+      'Hello',
+      expect.stringContaining('Squat:100')
+    );
   });
 
   it('sends message with coach context in free mode', async () => {
@@ -41,15 +51,21 @@ describe('Chatbot component', () => {
 
     render(<Chatbot workouts={[]} />);
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'free' } });
-    fireEvent.change(screen.getByPlaceholderText('Votre message...'), { target: { value: 'Yo' } });
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'free' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Votre message...'), {
+      target: { value: 'Yo' },
+    });
     fireEvent.click(screen.getByText('Envoyer'));
 
     expect(sendMessage).toHaveBeenCalledWith(
       'Yo',
       expect.stringContaining('coach sportif')
     );
-    await waitFor(() => expect(screen.getByPlaceholderText('Votre message...').value).toBe(''));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Votre message...').value).toBe('')
+    );
   });
 
   it('uses API key from environment variables', () => {

--- a/src/utils/workoutUtils.js
+++ b/src/utils/workoutUtils.js
@@ -11,39 +11,60 @@ export function parseLocalDate(dateStr) {
   return new Date(year, month - 1, day);
 }
 
-export const createWorkout = (exercises, date, duration, workoutId = undefined, startTime = null, endTime = null) => {
+export const createWorkout = (
+  exercises,
+  date,
+  duration,
+  workoutId = undefined,
+  startTime = null,
+  endTime = null
+) => {
   if (!exercises || exercises.length === 0) return null;
-  
+
   // S'assurer que tous les exercices ont un type valide
-  const validatedExercises = exercises.map(exercise => ({
+  const validatedExercises = exercises.map((exercise) => ({
     id: exercise.id || Date.now(),
     name: exercise.name || 'Exercice sans nom',
     type: exercise.type || 'custom', // Type par défaut si manquant
-    sets: (exercise.sets || [{ reps: 0, weight: 0, duration: 0 }]).map(set => ({
-      reps: parseInt(set.reps) || 0,
-      weight: parseFloat(String(set.weight).replace(',', '.')) || 0,
-      duration: parseInt(set.duration) || 0
-    }))
+    sets: (exercise.sets || [{ reps: 0, weight: 0, duration: 0 }]).map(
+      (set) => ({
+        reps: parseInt(set.reps) || 0,
+        weight: parseFloat(String(set.weight).replace(',', '.')) || 0,
+        duration: parseInt(set.duration) || 0,
+      })
+    ),
   }));
-  
+
   const workout = {
     date: date || new Date().toISOString().split('T')[0],
     exercises: validatedExercises,
     duration: parseInt(duration) || DEFAULT_WORKOUT_DURATION,
-    totalSets: validatedExercises.reduce((acc, ex) => acc + (ex.sets?.length || 0), 0),
-    totalReps: validatedExercises.reduce((acc, ex) => 
-      acc + (ex.sets?.reduce((setAcc, set) => setAcc + (set.reps || 0), 0) || 0), 0
+    totalSets: validatedExercises.reduce(
+      (acc, ex) => acc + (ex.sets?.length || 0),
+      0
     ),
-    totalWeight: validatedExercises.reduce((acc, ex) => 
-      acc + (ex.sets?.reduce((setAcc, set) => setAcc + ((set.weight || 0) * (set.reps || 0)), 0) || 0), 0
-    )
+    totalReps: validatedExercises.reduce(
+      (acc, ex) =>
+        acc +
+        (ex.sets?.reduce((setAcc, set) => setAcc + (set.reps || 0), 0) || 0),
+      0
+    ),
+    totalWeight: validatedExercises.reduce(
+      (acc, ex) =>
+        acc +
+        (ex.sets?.reduce(
+          (setAcc, set) => setAcc + (set.weight || 0) * (set.reps || 0),
+          0
+        ) || 0),
+      0
+    ),
   };
-  
+
   // Ajouter les champs optionnels seulement s'ils ont une valeur
   if (workoutId) workout.id = workoutId;
   if (startTime) workout.startTime = startTime;
   if (endTime) workout.endTime = endTime;
-  
+
   return workout;
 };
 
@@ -52,17 +73,26 @@ export const calculateWorkoutStats = (workouts) => {
   const totalSets = workouts.reduce((acc, w) => acc + w.totalSets, 0);
   const totalReps = workouts.reduce((acc, w) => acc + w.totalReps, 0);
   const totalWeight = workouts.reduce((acc, w) => acc + w.totalWeight, 0);
-  const avgDuration = totalWorkouts > 0 
-    ? Math.round(workouts.reduce((acc, w) => acc + w.duration, 0) / totalWorkouts) 
-    : 0;
-  
+  const avgDuration =
+    totalWorkouts > 0
+      ? Math.round(
+          workouts.reduce((acc, w) => acc + w.duration, 0) / totalWorkouts
+        )
+      : 0;
+
   return { totalWorkouts, totalSets, totalReps, totalWeight, avgDuration };
 };
 
 // Modifie formatDate pour utiliser parseLocalDate
 export const formatDate = (dateStr) => {
   const d = parseLocalDate(dateStr);
-  return d ? d.toLocaleDateString('fr-FR', { weekday: 'short', day: '2-digit', month: 'short' }) : '';
+  return d
+    ? d.toLocaleDateString('fr-FR', {
+        weekday: 'short',
+        day: '2-digit',
+        month: 'short',
+      })
+    : '';
 };
 
 export const getCurrentDate = () => {
@@ -71,56 +101,100 @@ export const getCurrentDate = () => {
   const month = String(now.getMonth() + 1).padStart(2, '0');
   const day = String(now.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
-}; 
+};
 
 // Gamification: retourne les badges débloqués selon les stats
 export function getBadges(stats) {
   const badges = [];
-  if (stats.totalWorkouts >= 1) badges.push({ key: 'badge_first_workout', label: 'Première séance', icon: '🏅' });
-  if (stats.totalWorkouts >= 5) badges.push({ key: 'badge_5_workouts', label: '5 séances', icon: '🥉' });
-  if (stats.totalWorkouts >= 10) badges.push({ key: 'badge_10_workouts', label: '10 séances', icon: '🥈' });
-  if (stats.totalWorkouts >= 20) badges.push({ key: 'badge_20_workouts', label: '20 séances', icon: '🥇' });
-  if (stats.totalSets >= 100) badges.push({ key: 'badge_100_sets', label: '100 séries', icon: '💪' });
-  if (stats.totalReps >= 1000) badges.push({ key: 'badge_1000_reps', label: '1000 reps', icon: '🔥' });
-  if (stats.totalWeight >= 10000) badges.push({ key: 'badge_10k_weight', label: '10 000 kg soulevés', icon: '🏋️' });
-  if (stats.avgDuration >= 60) badges.push({ key: 'badge_long_workout', label: 'Séances longues', icon: '⏱️' });
+  if (stats.totalWorkouts >= 1)
+    badges.push({
+      key: 'badge_first_workout',
+      label: 'Première séance',
+      icon: '🏅',
+    });
+  if (stats.totalWorkouts >= 5)
+    badges.push({ key: 'badge_5_workouts', label: '5 séances', icon: '🥉' });
+  if (stats.totalWorkouts >= 10)
+    badges.push({ key: 'badge_10_workouts', label: '10 séances', icon: '🥈' });
+  if (stats.totalWorkouts >= 20)
+    badges.push({ key: 'badge_20_workouts', label: '20 séances', icon: '🥇' });
+  if (stats.totalSets >= 100)
+    badges.push({ key: 'badge_100_sets', label: '100 séries', icon: '💪' });
+  if (stats.totalReps >= 1000)
+    badges.push({ key: 'badge_1000_reps', label: '1000 reps', icon: '🔥' });
+  if (stats.totalWeight >= 10000)
+    badges.push({
+      key: 'badge_10k_weight',
+      label: '10 000 kg soulevés',
+      icon: '🏋️',
+    });
+  if (stats.avgDuration >= 60)
+    badges.push({
+      key: 'badge_long_workout',
+      label: 'Séances longues',
+      icon: '⏱️',
+    });
   return badges;
 }
 
 // Analyse des habitudes d'entraînement basées sur l'heure
 export function analyzeWorkoutHabits(workouts) {
-  const morningWorkouts = workouts.filter(w => {
+  const morningWorkouts = workouts.filter((w) => {
     if (!w.startTime) return false;
     const hour = parseInt(w.startTime.split(':')[0]);
     return hour >= 5 && hour < 12;
   }).length;
-  
-  const afternoonWorkouts = workouts.filter(w => {
+
+  const afternoonWorkouts = workouts.filter((w) => {
     if (!w.startTime) return false;
     const hour = parseInt(w.startTime.split(':')[0]);
     return hour >= 12 && hour < 18;
   }).length;
-  
-  const eveningWorkouts = workouts.filter(w => {
+
+  const eveningWorkouts = workouts.filter((w) => {
     if (!w.startTime) return false;
     const hour = parseInt(w.startTime.split(':')[0]);
     return hour >= 18 && hour < 22;
   }).length;
-  
-  const nightWorkouts = workouts.filter(w => {
+
+  const nightWorkouts = workouts.filter((w) => {
     if (!w.startTime) return false;
     const hour = parseInt(w.startTime.split(':')[0]);
     return hour >= 22 || hour < 5;
   }).length;
-  
-  const totalWorkoutsWithTime = workouts.filter(w => w.startTime).length;
-  
+
+  const totalWorkoutsWithTime = workouts.filter((w) => w.startTime).length;
+
   return {
-    morning: { count: morningWorkouts, percentage: totalWorkoutsWithTime > 0 ? Math.round((morningWorkouts / totalWorkoutsWithTime) * 100) : 0 },
-    afternoon: { count: afternoonWorkouts, percentage: totalWorkoutsWithTime > 0 ? Math.round((afternoonWorkouts / totalWorkoutsWithTime) * 100) : 0 },
-    evening: { count: eveningWorkouts, percentage: totalWorkoutsWithTime > 0 ? Math.round((eveningWorkouts / totalWorkoutsWithTime) * 100) : 0 },
-    night: { count: nightWorkouts, percentage: totalWorkoutsWithTime > 0 ? Math.round((nightWorkouts / totalWorkoutsWithTime) * 100) : 0 },
-    totalWithTime: totalWorkoutsWithTime
+    morning: {
+      count: morningWorkouts,
+      percentage:
+        totalWorkoutsWithTime > 0
+          ? Math.round((morningWorkouts / totalWorkoutsWithTime) * 100)
+          : 0,
+    },
+    afternoon: {
+      count: afternoonWorkouts,
+      percentage:
+        totalWorkoutsWithTime > 0
+          ? Math.round((afternoonWorkouts / totalWorkoutsWithTime) * 100)
+          : 0,
+    },
+    evening: {
+      count: eveningWorkouts,
+      percentage:
+        totalWorkoutsWithTime > 0
+          ? Math.round((eveningWorkouts / totalWorkoutsWithTime) * 100)
+          : 0,
+    },
+    night: {
+      count: nightWorkouts,
+      percentage:
+        totalWorkoutsWithTime > 0
+          ? Math.round((nightWorkouts / totalWorkoutsWithTime) * 100)
+          : 0,
+    },
+    totalWithTime: totalWorkoutsWithTime,
   };
 }
 
@@ -131,11 +205,11 @@ export function getPreferredWorkoutTime(workouts) {
     { name: 'matin', ...habits.morning, icon: '🌅' },
     { name: 'après-midi', ...habits.afternoon, icon: '☀️' },
     { name: 'soir', ...habits.evening, icon: '🌆' },
-    { name: 'nuit', ...habits.night, icon: '🌙' }
+    { name: 'nuit', ...habits.night, icon: '🌙' },
   ];
-  
-  return times.reduce((prev, current) => 
-    (current.count > prev.count) ? current : prev
+
+  return times.reduce((prev, current) =>
+    current.count > prev.count ? current : prev
   );
 }
 
@@ -145,12 +219,12 @@ export function getAverageDurationByTime(workouts) {
     morning: { workouts: [], total: 0 },
     afternoon: { workouts: [], total: 0 },
     evening: { workouts: [], total: 0 },
-    night: { workouts: [], total: 0 }
+    night: { workouts: [], total: 0 },
   };
-  
-  workouts.forEach(workout => {
+
+  workouts.forEach((workout) => {
     if (!workout.startTime || !workout.duration) return;
-    
+
     const hour = parseInt(workout.startTime.split(':')[0]);
     if (hour >= 5 && hour < 12) {
       timeSlots.morning.workouts.push(workout);
@@ -166,20 +240,38 @@ export function getAverageDurationByTime(workouts) {
       timeSlots.night.total += workout.duration;
     }
   });
-  
+
   return {
-    morning: timeSlots.morning.workouts.length > 0 ? Math.round(timeSlots.morning.total / timeSlots.morning.workouts.length) : 0,
-    afternoon: timeSlots.afternoon.workouts.length > 0 ? Math.round(timeSlots.afternoon.total / timeSlots.afternoon.workouts.length) : 0,
-    evening: timeSlots.evening.workouts.length > 0 ? Math.round(timeSlots.evening.total / timeSlots.evening.workouts.length) : 0,
-    night: timeSlots.night.workouts.length > 0 ? Math.round(timeSlots.night.total / timeSlots.night.workouts.length) : 0
+    morning:
+      timeSlots.morning.workouts.length > 0
+        ? Math.round(
+            timeSlots.morning.total / timeSlots.morning.workouts.length
+          )
+        : 0,
+    afternoon:
+      timeSlots.afternoon.workouts.length > 0
+        ? Math.round(
+            timeSlots.afternoon.total / timeSlots.afternoon.workouts.length
+          )
+        : 0,
+    evening:
+      timeSlots.evening.workouts.length > 0
+        ? Math.round(
+            timeSlots.evening.total / timeSlots.evening.workouts.length
+          )
+        : 0,
+    night:
+      timeSlots.night.workouts.length > 0
+        ? Math.round(timeSlots.night.total / timeSlots.night.workouts.length)
+        : 0,
   };
 }
 
 // Filtre les workouts par plage de dates
 export function getWorkoutsForDateRange(workouts, startDate, endDate) {
   if (!workouts || !Array.isArray(workouts)) return [];
-  
-  return workouts.filter(workout => {
+
+  return workouts.filter((workout) => {
     const workoutDate = parseLocalDate(workout.date);
     return workoutDate >= startDate && workoutDate <= endDate;
   });
@@ -188,15 +280,17 @@ export function getWorkoutsForDateRange(workouts, startDate, endDate) {
 // Fonction pour nettoyer les données avant envoi à Firebase
 export function cleanWorkoutForFirestore(workout) {
   if (!workout) return null;
-  
+
   // Fonction récursive pour nettoyer les objets
   const cleanObject = (obj) => {
     if (obj === null || obj === undefined) return null;
     if (typeof obj !== 'object') return obj;
     if (Array.isArray(obj)) {
-      return obj.map(cleanObject).filter(item => item !== null && item !== undefined);
+      return obj
+        .map(cleanObject)
+        .filter((item) => item !== null && item !== undefined);
     }
-    
+
     const cleaned = {};
     for (const [key, value] of Object.entries(obj)) {
       if (value !== null && value !== undefined) {
@@ -205,22 +299,32 @@ export function cleanWorkoutForFirestore(workout) {
     }
     return cleaned;
   };
-  
+
   return cleanObject(workout);
 }
 
-export function getLastExerciseWeight(workouts, exerciseName, beforeDate = null) {
+export function getLastExerciseWeight(
+  workouts,
+  exerciseName,
+  beforeDate = null
+) {
   if (!Array.isArray(workouts) || !exerciseName) return null;
   const sorted = [...workouts].sort(
     (a, b) => parseLocalDate(b.date) - parseLocalDate(a.date)
   );
   for (const workout of sorted) {
-    if (beforeDate && parseLocalDate(workout.date) >= parseLocalDate(beforeDate)) continue;
+    if (
+      beforeDate &&
+      parseLocalDate(workout.date) >= parseLocalDate(beforeDate)
+    )
+      continue;
     const exercise = workout.exercises?.find(
-      ex => ex.name && ex.name.toLowerCase() === exerciseName.toLowerCase()
+      (ex) => ex.name && ex.name.toLowerCase() === exerciseName.toLowerCase()
     );
     if (exercise && Array.isArray(exercise.sets)) {
-      const weights = exercise.sets.map(s => parseFloat(s.weight || 0)).filter(w => w > 0);
+      const weights = exercise.sets
+        .map((s) => parseFloat(s.weight || 0))
+        .filter((w) => w > 0);
       if (weights.length > 0) {
         return weights[weights.length - 1];
       }
@@ -233,8 +337,8 @@ export function getLastExerciseWeight(workouts, exerciseName, beforeDate = null)
 export function getMuscleGroupDistribution(workouts) {
   if (!Array.isArray(workouts)) return {};
   const count = {};
-  workouts.forEach(w => {
-    w.exercises?.forEach(ex => {
+  workouts.forEach((w) => {
+    w.exercises?.forEach((ex) => {
       if (ex.type) {
         count[ex.type] = (count[ex.type] || 0) + 1;
       }
@@ -251,12 +355,15 @@ export function getMuscleGroupDistribution(workouts) {
 // Retourne la progression de poids moyenne par exercice entre la première et la dernière séance
 export function getWeightProgress(workouts) {
   if (!Array.isArray(workouts)) return {};
-  const sorted = [...workouts].sort((a, b) => parseLocalDate(a.date) - parseLocalDate(b.date));
+  const sorted = [...workouts].sort(
+    (a, b) => parseLocalDate(a.date) - parseLocalDate(b.date)
+  );
   const map = {};
-  sorted.forEach(w => {
-    w.exercises?.forEach(ex => {
+  sorted.forEach((w) => {
+    w.exercises?.forEach((ex) => {
       const weight = Array.isArray(ex.sets)
-        ? ex.sets.reduce((s, set) => s + (parseFloat(set.weight) || 0), 0) / (ex.sets.length || 1)
+        ? ex.sets.reduce((s, set) => s + (parseFloat(set.weight) || 0), 0) /
+          (ex.sets.length || 1)
         : 0;
       if (!map[ex.name]) {
         map[ex.name] = { first: weight, last: weight };
@@ -277,10 +384,10 @@ export function getAverageWeights(workouts) {
   if (!Array.isArray(workouts)) return {};
   const totals = {};
   const counts = {};
-  workouts.forEach(w => {
-    w.exercises?.forEach(ex => {
+  workouts.forEach((w) => {
+    w.exercises?.forEach((ex) => {
       if (Array.isArray(ex.sets)) {
-        ex.sets.forEach(set => {
+        ex.sets.forEach((set) => {
           const weight = parseFloat(set.weight) || 0;
           totals[ex.name] = (totals[ex.name] || 0) + weight;
           counts[ex.name] = (counts[ex.name] || 0) + 1;
@@ -289,8 +396,26 @@ export function getAverageWeights(workouts) {
     });
   });
   const averages = {};
-  Object.keys(totals).forEach(name => {
+  Object.keys(totals).forEach((name) => {
     averages[name] = Math.round(totals[name] / counts[name]);
   });
   return averages;
+}
+
+// Retourne un résumé détaillé du poids de chaque exercice pour chaque séance
+export function getWorkoutWeightDetails(workouts) {
+  if (!Array.isArray(workouts)) return '';
+  return workouts
+    .map((w) => {
+      const exercises = (w.exercises || [])
+        .map((ex) => {
+          const weights = (ex.sets || [])
+            .map((set) => parseFloat(set.weight) || 0)
+            .join('/');
+          return `${ex.name}:${weights}`;
+        })
+        .join(', ');
+      return `${w.date} - ${exercises}`;
+    })
+    .join('; ');
 }


### PR DESCRIPTION
## Summary
- expose utility to get detailed weight info for recent workouts
- display weight details in Chatbot messages
- test weight detail helper and Chatbot context

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6881c390593483318d992674cfb24dcb