### PR TITLE
Remove weight averages from chatbot summary

### DIFF
--- a/src/components/Chatbot/Chatbot.jsx
+++ b/src/components/Chatbot/Chatbot.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import useChatGPT from '../../hooks/useChatGPT';
 import {
   getMuscleGroupDistribution,
-  getAverageWeights,
   getWorkoutWeightDetails,
 } from '../../utils/workoutUtils';
 
@@ -23,13 +22,7 @@ const Chatbot = ({ workouts }) => {
       .map(([muscle, percent]) => `${muscle}:${percent}%`)
       .join(', ');
 
-    const weights = getAverageWeights(workouts);
-    const weightString = Object.entries(weights)
-      .slice(0, 3)
-      .map(([name, avg]) => `${name}:${avg}kg`)
-      .join(', ');
-
-    return `Répartition ${distString}. Poids ${weightString}`;
+    return `Répartition ${distString}`;
   };
 
   const getDetails = () => {

--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -33,10 +33,6 @@ describe('Chatbot component', () => {
     );
     expect(sendMessage).toHaveBeenCalledWith(
       'Hello',
-      expect.stringContaining('Poids')
-    );
-    expect(sendMessage).toHaveBeenCalledWith(
-      'Hello',
       expect.stringContaining('2024-01-01')
     );
     expect(sendMessage).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- remove average weight info from chatbot
- update chatbot tests accordingly

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881c949bc60833197840a941a31a227