### PR TITLE
Add rep and set info to chatbot

### DIFF
--- a/src/components/Chatbot/Chatbot.jsx
+++ b/src/components/Chatbot/Chatbot.jsx
@@ -4,6 +4,7 @@ import useChatGPT from '../../hooks/useChatGPT';
 import {
   getMuscleGroupDistribution,
   getWorkoutWeightDetails,
+  getWorkoutSetRepDetails,
 } from '../../utils/workoutUtils';
 
 const Chatbot = ({ workouts }) => {
@@ -41,13 +42,18 @@ const Chatbot = ({ workouts }) => {
     return getWorkoutWeightDetails(workouts.slice(-3));
   };
 
+  const getSetRepDetails = () => {
+    if (!workouts || workouts.length === 0) return '';
+    return getWorkoutSetRepDetails(workouts.slice(-3));
+  };
+
   const handleSend = async () => {
     if (!input.trim()) return;
     const base =
       'Tu es mon coach sportif personnel. Sois motivant et adapte tes conseils à mon niveau.';
     const context =
       mode === 'advice'
-        ? `${base} Analyse mes séances précédentes. ${getSummary()} ${getDetails()} ${getWeightDetails()} Donne-moi des conseils précis.`
+        ? `${base} Analyse mes séances précédentes. ${getSummary()} ${getDetails()} ${getWeightDetails()} ${getSetRepDetails()} Donne-moi des conseils précis.`
         : base;
     await sendMessage(input, context);
     setInput('');

--- a/src/tests/components/Chatbot.test.js
+++ b/src/tests/components/Chatbot.test.js
@@ -13,7 +13,7 @@ describe('Chatbot component', () => {
     const workouts = [
       {
         date: '2024-01-01',
-        exercises: [{ name: 'Squat', sets: [{ weight: 100 }] }],
+        exercises: [{ name: 'Squat', sets: [{ reps: 5, weight: 100 }] }],
         duration: 30,
       },
     ];
@@ -34,6 +34,10 @@ describe('Chatbot component', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       'Hello',
       expect.stringContaining('2024-01-01')
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      'Hello',
+      expect.stringContaining('Squat:5x100')
     );
     expect(sendMessage).toHaveBeenCalledWith(
       'Hello',

--- a/src/tests/utils/workoutUtils.test.js
+++ b/src/tests/utils/workoutUtils.test.js
@@ -14,6 +14,7 @@ import {
   getWeightProgress,
   getAverageWeights,
   getWorkoutWeightDetails,
+  getWorkoutSetRepDetails,
 } from '../../utils/workoutUtils';
 
 describe('workoutUtils', () => {
@@ -164,5 +165,25 @@ describe('workoutUtils', () => {
     expect(details).toContain('Squat:100/110');
     expect(details).toContain('2024-01-02');
     expect(details).toContain('Bench:80');
+  });
+
+  it('generates rep and set details', () => {
+    const workouts = [
+      {
+        date: '2024-01-01',
+        exercises: [
+          { name: 'Squat', sets: [{ reps: 5, weight: 100 }, { reps: 5, weight: 110 }] },
+        ],
+      },
+      {
+        date: '2024-01-02',
+        exercises: [{ name: 'Bench', sets: [{ reps: 8, weight: 80 }] }],
+      },
+    ];
+    const details = getWorkoutSetRepDetails(workouts);
+    expect(details).toContain('2024-01-01');
+    expect(details).toContain('Squat:5x100/5x110');
+    expect(details).toContain('2024-01-02');
+    expect(details).toContain('Bench:8x80');
   });
 });

--- a/src/utils/workoutUtils.js
+++ b/src/utils/workoutUtils.js
@@ -419,3 +419,21 @@ export function getWorkoutWeightDetails(workouts) {
     })
     .join('; ');
 }
+
+// Retourne un résumé détaillé des répétitions et poids de chaque série
+export function getWorkoutSetRepDetails(workouts) {
+  if (!Array.isArray(workouts)) return '';
+  return workouts
+    .map((w) => {
+      const exercises = (w.exercises || [])
+        .map((ex) => {
+          const sets = (ex.sets || [])
+            .map((set) => `${set.reps || 0}x${parseFloat(set.weight) || 0}`)
+            .join('/');
+          return `${ex.name}:${sets}`;
+        })
+        .join(', ');
+      return `${w.date} - ${exercises}`;
+    })
+    .join('; ');
+}


### PR DESCRIPTION
## Summary
- add `getWorkoutSetRepDetails` util to build rep & weight strings
- show rep and set details in Chatbot context
- test new util and chatbot behavior with reps

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6881cdaea85883319a5a54ee2294d4a7